### PR TITLE
Copy self.headers dictionnary before updating

### DIFF
--- a/modules/vectra.py
+++ b/modules/vectra.py
@@ -194,7 +194,7 @@ class VectraClient(object):
         if not host_id:
             raise ValueError('Host id required')
 
-        headers = self.headers
+        headers = self.headers.copy()
         headers.update({
             'Content-Type': 'application/x-www-form-urlencoded'
         })
@@ -239,7 +239,7 @@ class VectraClient(object):
         else:
             raise TypeError('tags must be of type list')
 
-        headers = self.headers
+        headers = self.headers.copy()
         headers.update({
             'Content-Type': "application/json",
             'Cache-Control': "no-cache"
@@ -345,7 +345,7 @@ class VectraClient(object):
         else:
             raise TypeError('tags must be of type list')
 
-        headers = self.headers
+        headers = self.headers.copy()
         headers.update({
             'Content-Type': "application/json",
             'Cache-Control': "no-cache"
@@ -515,7 +515,7 @@ class VectraClient(object):
             }
         }
 
-        headers = self.headers
+        headers = self.headers.copy()
         headers.update({
             'Content-Type': "application/json",
             'Cache-Control': "no-cache"


### PR DESCRIPTION
Copy self.headers before editing, instead of creating only a new reference to it. This allows to re-use the same VectraClient instance to call multiple methods. 
I had a case where I created a new threat feed and then uploaded a STIX file the newly created feed. The issue is that since the "create_feed" function alters the "headers" attribute of the VectraClient instance to contain 'Content-Type': "application/json". When using the same VectraClient instance when calling "post_stix_file", the upload of a STIX file failed since we still sent the headers telling the API to expect JSON. 