### PR TITLE
Copy self.headers instead of creating a reference

### DIFF
--- a/modules/vectra.py
+++ b/modules/vectra.py
@@ -500,7 +500,7 @@ class VectraClient(object):
     @validate_api_v2
     @request_error_handler
     def add_proxy(self, address=None, enable=True):
-        headers = self.headers
+        headers = self.headers.copy()
         headers.update({
             "Content-Type": "application/json"
         })
@@ -517,7 +517,7 @@ class VectraClient(object):
     @validate_api_v2
     @request_error_handler
     def update_proxy(self, proxy_id=None, address=None, enable=True):
-        headers = self.headers
+        headers = self.headers.copy()
         headers.update({
             "Content-Type": "application/json"
         })


### PR DESCRIPTION
Modifying the self.headers dict (by reference) causes issues when reusing the VectraClient instance. When modifying headers for a method, we should do so on a copy.