### PR TITLE
Return <Requests> object for get_all_detections

### DIFF
--- a/modules/vectra.py
+++ b/modules/vectra.py
@@ -293,7 +293,7 @@ class VectraClient(object):
         while resp.json()['next']:
             url = resp.json()['next']
             path = url.replace(self.url, '')
-            resp = self.custom_endpoint(path=path).json()
+            resp = self.custom_endpoint(path=path)
             yield resp
 
     @request_error_handler


### PR DESCRIPTION
Corrected an issue where get_all_detections returns the json() representation of the <requests> object instead of the <requests> object itself after the first iteration.