### PR TITLE
Feature/app 6765 add note modified

### DIFF
--- a/modules/vectra.py
+++ b/modules/vectra.py
@@ -77,7 +77,7 @@ class VectraClient(object):
         :rtype: dict
         """
         params = {}
-        valid_keys = ['active_traffic', 'c_score', 'c_score_gte', 'certainty', 'certainty_gte', 'fields',
+        valid_keys = ['all', 'active_traffic', 'c_score', 'c_score_gte', 'certainty', 'certainty_gte', 'fields',
                       'has_active_traffic', 'include_detection_summaries', 'is_key_asset', 'is_targeting_key_asset',
                       'key_asset', 'last_source', 'mac_address', 'name', 'ordering', 'page', 'page_size', 'state',
                       't_score', 't_score_gte', 'tags', 'threat', 'threat_gte', 'targets_key_asset']

--- a/modules/vectra.py
+++ b/modules/vectra.py
@@ -523,12 +523,11 @@ class VectraClient(object):
         })
 
         proxy = self.get_proxies(proxy_id=proxy_id).json()['proxies']
-        payload = {
-            "proxy": {
-                "address": address if address else proxy['ip'],
-                "considerProxy": enable
-            }
-        }
+        payload = {"proxy": {}}
+        if address is not None:
+            payload["proxy"]["address"] = address 
+        if enable is not None:
+            payload["proxy"]["considerProxy"] = enable
 
         return requests.patch('{url}/proxies/{id}'.format(url=self.url, id=proxy_id), json=payload, headers=headers,
                               verify=self.verify)

--- a/modules/vectra.py
+++ b/modules/vectra.py
@@ -80,7 +80,7 @@ class VectraClient(object):
         valid_keys = ['all', 'active_traffic', 'c_score', 'c_score_gte', 'certainty', 'certainty_gte', 'fields',
                       'has_active_traffic', 'include_detection_summaries', 'is_key_asset', 'is_targeting_key_asset',
                       'key_asset', 'last_source', 'mac_address', 'name', 'ordering', 'page', 'page_size', 'state',
-                      't_score', 't_score_gte', 'tags', 'threat', 'threat_gte', 'targets_key_asset']
+                      't_score', 't_score_gte', 'tags', 'threat', 'threat_gte', 'targets_key_asset', 'note_modified_timestamp_gte']
         deprecated_keys = ['c_score', 'c_score_gte', 'key_asset', 't_score', 't_score_gte', 'targets_key_asset']
         for k, v in args.items():
             if k in valid_keys and v is not None: params[k] = v
@@ -98,7 +98,7 @@ class VectraClient(object):
         valid_keys = ['c_score', 'c_score_gte', 'category', 'certainty', 'certainty_gte', 'detection', 'detection_type',
                       'detection_category', 'fields', 'host_id', 'is_targeting_key_asset', 'is_triaged', 'ordering',
                       'page', 'page_size', 'src_ip', 'state', 't_score', 't_score_gte', 'tags', 'targets_key_asset',
-                      'threat', 'threat_gte']
+                      'threat', 'threat_gte', 'note_modified_timestamp_gte']
         deprecated_keys = ['c_score', 'c_score_gte', 'category', 'detection', 't_score', 't_score_gte', 'targets_key_asset']
         for k, v in args.items():
             if k in valid_keys and v is not None: params[k] = v
@@ -143,6 +143,7 @@ class VectraClient(object):
         :param targets_key_asset: host is targeting key asset (bool)
         :param threat: threat score (int)
         :param threat_gte: threat score greater than or equal to (int)
+        :param note_modified_timestamp_gte: note last modified timestamp greater than or equal to (int)
         """
 
         if self.version == 2:
@@ -274,6 +275,7 @@ class VectraClient(object):
         :param targets_key_asset: detection targets key asset (bool) - will be removed with deprecation of v1 of api
         :param threat: threat score (int)
         :param threat_gte threat score is greater than or equal to (int)
+        :param note_modified_timestamp_gte: note last modified timestamp greater than or equal to (int)
         """
 
         if self.version == 2:
@@ -525,7 +527,7 @@ class VectraClient(object):
         proxy = self.get_proxies(proxy_id=proxy_id).json()['proxies']
         payload = {"proxy": {}}
         if address is not None:
-            payload["proxy"]["address"] = address 
+            payload["proxy"]["address"] = address
         if enable is not None:
             payload["proxy"]["considerProxy"] = enable
 

--- a/scripts/subnet_count.py
+++ b/scripts/subnet_count.py
@@ -25,8 +25,11 @@ def main():
                         action='store_true')
     parser.add_argument('--list_hosts', help='add host list to csv',
                         action='store_true')
+    parser.add_argument('--all-hosts', action='store_true',
+                        help='return active and inactive hosts (only active hosts by default)')
 
     args = vars(parser.parse_args())
+    print args
 
     if args['user']:
         args['password'] = getPassword()
@@ -37,7 +40,7 @@ def main():
     total_count = 0
     subnets = {}
 
-    for page in vc.get_all_hosts(fields='name,last_source'):
+    for page in vc.get_all_hosts(all=args['all_hosts'], fields='name,last_source'):
         for host in page.json()['results']:
             if not host['last_source']:
                 continue

--- a/test/test_vectra_detection_v2.py
+++ b/test/test_vectra_detection_v2.py
@@ -43,3 +43,11 @@ def test_detection_tags(vc_v2):
 
     vc_v2.set_detection_tags(detection_id=detection_id, tags=detection_tags)
     assert vc_v2.get_detection_tags(detection_id=detection_id).json()['tags'] == detection_tags
+
+
+def test_get_detections_note_modified_apiv2(vc_v2):
+    resp = vc_v2.get_detections(note_modified_timestamp_gte=1000)
+
+    assert vc_v2.version == 2
+    assert resp.status_code == 200
+

--- a/test/test_vectra_host_v2.py
+++ b/test/test_vectra_host_v2.py
@@ -15,6 +15,13 @@ def test_get_hosts(vc_v2):
     assert resp.status_code == 200
 
 
+def test_get_hosts_note_modified(vc_v2):
+    resp = vc_v2.get_hosts(note_modified_timestamp_gte=100)
+
+    assert vc_v2.version == 2
+    assert resp.status_code == 200
+
+
 def test_host_generator(vc_v2):
     host_gen = vc_v2.get_all_hosts(page_size=1)
     results = next(host_gen)

--- a/test/test_vectra_proxies.py
+++ b/test/test_vectra_proxies.py
@@ -23,7 +23,6 @@ def test_proxy_add(vc_v2):
     assert resp.status_code == 200
     assert proxy['ip'] == '192.168.254.254'
     assert proxy['considerProxy'] == True
-    assert proxy['source'] == 'user'
 
 
 def test_proxy_address_update(vc_v2):
@@ -33,7 +32,6 @@ def test_proxy_address_update(vc_v2):
     assert resp.status_code == 200
     assert proxy['ip'] == '192.168.254.253'
     assert proxy['considerProxy'] == True
-    assert proxy['source'] == 'user'
 
 
 def test_proxy_state_update(vc_v2):
@@ -43,4 +41,3 @@ def test_proxy_state_update(vc_v2):
     assert resp.status_code == 200
     assert proxy['ip'] == '192.168.254.253'
     assert proxy['considerProxy'] == False
-    assert proxy['source'] == 'user'


### PR DESCRIPTION
- Added note_modified_timestamp_gte param to hosts and detection v2 endpoints.
- Fixed proxy client and its unit tests

Testing:
added unit tests
```
import vat.vectra as vectra
vc = vectra.VectraClient(url='https://x4-2-10.sc.tvec', token='7a04023dafdf4571c0b3d63194796cc3f5ad4d43', verify=False)
vc.get_hosts()

/home/vadmin/.local/lib/python2.7/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
<Response [200]>

vc.get_hosts(note_modified_timestamp_gte='adsfads')
/home/vadmin/.local/lib/python2.7/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "build/bdist.linux-x86_64/egg/vat/vectra.py", line 17, in request_handler
Exception: (400, '{"_meta":{"message":"Invalid field(s) found","level":"error"},"note_modified_timestamp_gte":"Invalid value given for parameter \'note_modified_timestamp_gte\'. Must be a valid timestamp: 2017-12-31T16:55:50Z."}')
>>>
```
