### PR TITLE
API_Version2_to_2.5

### DIFF
--- a/modules/vectra.py
+++ b/modules/vectra.py
@@ -91,7 +91,7 @@ class VectraClient(object):
         url = VectraClient._remove_trailing_slashes(url)
 
         if token:
-            self.url = f'{url}/api/v2'
+            self.url = f'{url}/api/v2.5'
             self.headers = {
                 'Authorization': "Token " + token.strip(),
                 'Content-Type': "application/json",


### PR DESCRIPTION
As we are working on the Vectra client, we were not able to query Azure sensor detections, that was solved by changing the api url to 2.5, kindly approve the pull request to be able to use it in our integrations.