### PR TITLE
Corrected issue in generating group/rule parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ The current repository is broken down into the following:
 * _modules_ - this directory contains the modules associated with the VAT library
 * _scripts_ - collection of scripts to interact with the Vectra api. These scripts can be used as-is or as a reference on how to leverage the VAT library
 * _test_ - collection of tests that can be used to validate the VAT library
-* _Vectra\_APIv1.postman\_collection_ is a Postman collection for the Vectra API. It has all of the current endpoints and and associated parameters for each endpoint
 
 **Wiki**  
 https://github.com/vectranetworks/vectra_api_tools/wiki
@@ -29,4 +28,16 @@ pip install git+https://github.com/vectranetworks/vectra_api_tools.git@develop
 source:
 ```
 python setup.py install
+```
+
+**Instantiation**
+* For v2
+```
+import vat.vectra as detect
+detect_client = detect.VectraClientV2_5(url="",token="")
+```
+* For v3
+```
+import vat.platform as platform
+platform_client = platform.VectraPlatformClientV3_3(url="",client_id="",secret_key="")
 ```

--- a/modules/platform.py
+++ b/modules/platform.py
@@ -607,6 +607,7 @@ class VectraPlatformClientV3_2(VectraPlatformClientV3_1):
             "last_modified_timestamp",
             "last_modified_by",
             "name",
+            "page_size",
             "type",
         ]
 
@@ -662,9 +663,11 @@ class VectraPlatformClientV3_3(VectraPlatformClientV3_2):
             "state",
             "last_source",
             "threat",
+            "threat_gte",
             "t_score",
             "t_score_gte",
             "certainty",
+            "certainty_gte",
             "c_score",
             "c_score_gte",
             "last_detection_timestamp",
@@ -693,11 +696,13 @@ class VectraPlatformClientV3_3(VectraPlatformClientV3_2):
         valid_keys = [
             "account_ids",
             "account_names",
-            "host_ids" "importance",
+            "host_ids",
+            "importance",
             "description",
             "last_modified_timestamp",
             "last_modified_by",
             "name",
+            "page_size",
             "type",
         ]
 


### PR DESCRIPTION
Moved _generate_rule_params from base client to v2.4. Removed _generate_group_params from v2.5 as it was duplicate from 2.4. Corrected bug in _generate_params v3.3