### PR TITLE
Updated v3 audits to correct url

### DIFF
--- a/modules/platform.py
+++ b/modules/platform.py
@@ -343,7 +343,7 @@ class VectraPlatformClientV3(VectraClientV2_5):
         return _generate_params(args, valid_keys, deprecated_keys)
 
     @staticmethod
-    def _generate_audit_log_params(args):
+    def _generate_audit_params(args):
         """
         Generate query parameters for accounts based on provided args
         :param args: dict of keys to generate query params
@@ -419,6 +419,16 @@ class VectraPlatformClientV3(VectraClientV2_5):
             method="get",
             url=f"{self.url}/events/account_detection",
             params=self._generate_account_event_params(kwargs),
+        )
+
+    def get_audits(self, **kwargs):
+        """
+        see _generate_audit_params for available parameters
+        """
+        return self._request(
+            method="get",
+            url=f"{self.url}/events/audits",
+            params=self._generate_audit_params(kwargs),
         )
 
 

--- a/modules/vectra.py
+++ b/modules/vectra.py
@@ -52,6 +52,11 @@ class HTTPTooManyRequestsException(HTTPException):
         super().__init__(response)
 
 
+class HTTPContentTooLargeException(HTTPException):
+    def __init__(self, response):
+        super().__init__(response)
+
+
 def request_error_handler(func):
     def request_handler(self, *args, **kwargs):
         response = func(self, *args, **kwargs)
@@ -59,6 +64,8 @@ def request_error_handler(func):
             return response
         elif response.status_code == 401:
             raise HTTPUnauthorizedException(response)
+        elif response.status_code == 413:
+            raise HTTPContentTooLargeException(response)
         elif response.status_code == 422:
             raise HTTPTUnprocessableContentException(response)
         elif response.status_code == 429:
@@ -2545,7 +2552,7 @@ class VectraClientV2_1(VectraBaseClient):
             params=self._generate_detect_usage_params(kwargs),
         )
 
-    @validate_gte_api_v2
+    @validate_api_v2
     def get_audits(self, start_date=None, end_date=None):
         """
         Get audits between start_date and end_date, inclusive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vectra-api-tools"
-version = "3.3.0"
+version = "3.3.1"
 authors = [
   { name="Brandon Wyatt", email="bwyatt@vectra.ai" },
   { name="Vectra", email="tme@vectra.ai" },

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description="Vectra API client library",
     long_description=long_desc,
     long_description_content_type="text/markdown",
-    version="3.3.0",
+    version="3.3.1",
     author="Vectra",
     author_email="bwyatt@vectra.ai",
     url="https://github.com/vectranetworks/vectra_api_tools",

--- a/test.py
+++ b/test.py
@@ -1,0 +1,10 @@
+from vat import platform as v3
+
+client = v3.ClientV3_latest(
+    url="https://203120373595.uw2.portal.vectra.ai",
+    client_id="22a6e038ef6b441f9b6f773fdba454b0",
+    secret_key="WFFGTk1CRkNSNFhFNEZQVkY1QjJFU0RCVVlHWUJVSEY1TDVWUFdLTEhFRU1STEk2RlJIQUU_Z2wkazJeOFA4Qj8yb0c",
+)
+
+for audit in client.get_audits():
+    print(audit)


### PR DESCRIPTION
The URL for audits changed for v3, but the client was utilizing the v2 URL scheme. Created a get_audits function in v3 to utilize the relevant scheme.