### PR TITLE
force the correct case for arguments in create_feed()

### DIFF
--- a/modules/vectra.py
+++ b/modules/vectra.py
@@ -1707,6 +1707,10 @@ class VectraBaseClient(object):
         :param duration: days that the threat feed will be applied
         :returns: request object
         """
+        category = category.lower()
+        certainty = certainty.capitalize()
+        itype = itype.capitalize()
+
         if category not in ["lateral", "exfil", "cnc"]:
             raise ValueError(f"Invalid category provided: {category}")
 


### PR DESCRIPTION
The capitlization for arguements to create_feed is inconsistent (category needs to be all lower case, while certainty and itype are first letter capitalized). This sets the correct case so users do need to each time.