### PR TITLE
Feature/3.4.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .DS_Store
 .coverage
 .env
-.gitignore
 .pdm-python
 .pytest_cache
 .vscode

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,649 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=7
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.13
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+#max-args=5
+max-args=8
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=10
+
+# Maximum number of positional arguments for function / method.
+#max-positional-arguments=5
+max-positional-arguments=8
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# Maximum number of lines in a module.
+max-module-lines=2000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are: text, parseable, colorized,
+# json2 (improved json format), json (old json format) and msvs (visual
+# studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=yes
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,15 +1,16 @@
-### Environment
-Operating system:  
-Python version:  
-VAT version:  
-Vectra version:  
+## Environment
 
-### Exptected behavior
+Operating system:
+Python version:
+VAT version:
+Vectra version:
 
+## Expected behavior
 
+## Actual behavior
 
-### Actual behavior
+## Steps to reproduce
 
-
-
-### Steps to reproduce
+1.
+2.
+3.

--- a/modules/cli.py
+++ b/modules/cli.py
@@ -1,31 +1,33 @@
 import getpass
 
+
 def commonArgs(parser):
-    parser.add_argument('--url',
-                        required=True,
-                        help='IP or FQDN for Vectra brain (http://www.example.com)')
+    parser.add_argument(
+        "--url",
+        required=True,
+        help="IP or FQDN for Vectra brain (http://www.example.com)",
+    )
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('--token',
-                       help='api token')
-    group.add_argument('--user',
-                       help='username for basic auth')
-    parser.add_argument('--page',
-                        help='page number to when returnining multiple pages')
-    parser.add_argument('--size',
-                        dest='page_size',
-                        help='number of results to return per page (default: %(default)s)',
-                        default=5000)
-    parser.add_argument('--state',
-                        choices=['active', 'inactive'],
-                        help='state of object (default: %(default)s)',
-                        default='active')
-    parser.add_argument('--fields',
-                        help='fields to return')
-    parser.add_argument('--order',
-                        help='field to use for ordering')
+    group.add_argument("--token", help="api token")
+    group.add_argument("--user", help="username for basic auth")
+    parser.add_argument("--page", help="page number to when returnining multiple pages")
+    parser.add_argument(
+        "--size",
+        dest="page_size",
+        help="number of results to return per page (default: %(default)s)",
+        default=5000,
+    )
+    parser.add_argument(
+        "--state",
+        choices=["active", "inactive"],
+        help="state of object (default: %(default)s)",
+        default="active",
+    )
+    parser.add_argument("--fields", help="fields to return")
+    parser.add_argument("--order", help="field to use for ordering")
 
     return parser
 
 
 def getPassword():
-    return getpass.getpass(prompt='Please enter password')
+    return getpass.getpass(prompt="Please enter password")

--- a/modules/stix_taxii.py
+++ b/modules/stix_taxii.py
@@ -16,9 +16,20 @@ if sys.version_info.major == 3:
 
 
 class TaxiiClient(object):
-    def __init__(self, url=None, discovery_path=None, https=True, username=None, password=None, cert=None, key=None):
+    def __init__(
+        self,
+        url=None,
+        discovery_path=None,
+        https=True,
+        username=None,
+        password=None,
+        cert=None,
+        key=None,
+    ):
         self.client = create_client(url, use_https=https, discovery_path=discovery_path)
-        self.client.set_auth(username=username, password=password, cert_file=cert, key_file=key)
+        self.client.set_auth(
+            username=username, password=password, cert_file=cert, key_file=key
+        )
 
     def discovery(self, uri=None):
         if uri:
@@ -42,7 +53,9 @@ class TaxiiClient(object):
             duration = int(duration)
 
         begin_date = datetime.datetime.today() - datetime.timedelta(duration)
-        begin_date = begin_date.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.utc)
+        begin_date = begin_date.replace(
+            hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.utc
+        )
         packages = self.client.poll(collection_name=feed, begin_date=begin_date)
 
         return self._generate_stix_package(packages)
@@ -60,12 +73,14 @@ class TaxiiClient(object):
         return compiled_package
 
     @staticmethod
-    def write_stix_file(stix_package, dir='/tmp'):
-        ext = ''.join([random.choice(string.ascii_letters + string.digits) for n in range(10)])
-        fd = open('{0}/stix_{1}'.format(dir, str(ext)), 'w')
+    def write_stix_file(stix_package, dir="/tmp"):
+        ext = "".join(
+            [random.choice(string.ascii_letters + string.digits) for n in range(10)]
+        )
+        fd = open("{0}/stix_{1}".format(dir, str(ext)), "w")
         if pyversion == 2:
-            fd.write(stix_package.to_xml(encoding='utf-8'))
+            fd.write(stix_package.to_xml(encoding="utf-8"))
         if pyversion == 3:
-            fd.write(stix_package.to_xml(encoding='utf-8').decode())
+            fd.write(stix_package.to_xml(encoding="utf-8").decode())
         fd.close()
         return fd.name

--- a/modules/vectra.py
+++ b/modules/vectra.py
@@ -1,6 +1,5 @@
 import concurrent.futures
 import copy
-import html
 import ipaddress
 import json
 import os
@@ -70,25 +69,24 @@ def request_error_handler(func):
         response = func(self, *args, **kwargs)
         if response.status_code in [200, 201, 204]:
             return response
-        elif response.status_code == 401:
+        if response.status_code == 401:
             raise HTTPUnauthorizedException(response)
-        elif response.status_code == 409:
+        if response.status_code == 409:
             raise HTTPAlreadyExists(response)
-        elif response.status_code == 413:
+        if response.status_code == 413:
             raise HTTPRequestEntityTooLarge(response)
-        elif response.status_code == 422:
+        if response.status_code == 422:
             raise HTTPUnprocessableContentException(response)
-        elif response.status_code == 429:
+        if response.status_code == 429:
             raise HTTPTooManyRequestsException(response)
-        else:
-            if self._debug:
-                print(response.request.url)
-                print(response.request.headers)
-                try:
-                    print(response.request.data)
-                except AttributeError:
-                    print(response.request.body)
-            raise HTTPException(response)
+        if self._debug:
+            print(response.request.url)
+            print(response.request.headers)
+            try:
+                print(response.request.data)
+            except AttributeError:
+                print(response.request.body)
+        raise HTTPException(response)
 
     return request_handler
 
@@ -135,8 +133,7 @@ def validate_gte_api_v3_3(func):
     def api_validator(self, *args, **kwargs):
         if self.version < 3 or self.version >= 3.3:
             return func(self, *args, **kwargs)
-        else:
-            raise NotImplementedError("Method is accessible via v2 or v3.3+ of API")
+        raise NotImplementedError("Method is accessible via v2 or v3.3+ of API")
 
     return api_validator
 
@@ -157,8 +154,7 @@ def validate_api_v2(func):
     def api_validator(self, *args, **kwargs):
         if 3 > self.version >= 2:
             return func(self, *args, **kwargs)
-        else:
-            raise NotImplementedError("Method is only accessible via v2 of API")
+        raise NotImplementedError("Method is only accessible via v2 of API")
 
     return api_validator
 
@@ -168,8 +164,7 @@ def validate_api_v3(func):
     def api_validator(self, *args, **kwargs):
         if self.version >= 3:
             return func(self, *args, **kwargs)
-        else:
-            raise NotImplementedError("Method is not accessible via v2 of API")
+        raise NotImplementedError("Method is not accessible via v2 of API")
 
     return api_validator
 
@@ -183,10 +178,10 @@ def _format_url(url):
     return url
 
 
-class VectraBaseClient(object):
-    VERSION3 = 3
-    VERSION2 = 2
-    VERSION1 = 1
+class VectraClientV2_5:
+    VERSION3 = None
+    VERSION2 = 2.5
+    VERSION1 = None
     _debug = False
 
     def __init__(
@@ -292,6 +287,487 @@ class VectraBaseClient(object):
                 **kwargs,
             )
 
+    def get_threaded(self, url, count, **kwargs):
+        page_size = kwargs.get("params", {}).get("page_size", 5000)
+        try:
+            kwargs["params"].pop("page", None)
+        except KeyError:
+            pass
+        pages = ceil(count / page_size)
+
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self.threads, thread_name_prefix="Get All Generator"
+        ) as executor:
+            try:
+                results = {
+                    executor.submit(
+                        self._request,
+                        method="get",
+                        url=url + f"?page={page}&page_size={page_size}",
+                        params=kwargs.get("params", {}),
+                    ): page
+                    for page in range(2, pages + 1)
+                }
+                for result in concurrent.futures.as_completed(results):
+                    yield result.result()
+            except KeyboardInterrupt:
+                executor.shutdown(wait=False, cancel_futures=True)
+
+    def yield_results(self, resp, method, **kwargs):
+        if self.threads == 1:
+            while resp.json()["next"]:
+                resp = self._request(method=method, url=resp.json()["next"])
+                yield resp
+        else:
+            count = resp.json()["count"]
+            yield from self.get_threaded(resp.url.split("?")[0], count, **kwargs)
+
+    @staticmethod
+    def _generate_campaign_params(args):
+        """
+        Generate query parameters for campaigns based on provided args
+        :param args: dict of keys to generate query params
+        :rtype: dict
+
+        Valid keys in the dict
+        :param dst_ip: filter on campaign destination IP
+        :param target_domain: filter on campaign destination domain
+        :param state: campaign state, possible values are: init, active, closed, closed_never_active
+        :param name: filter on campaign name
+        :param last_updated_gte: return only campaigns with a last updated timestamp gte (datetime)
+        :param note_modified_timestamp_gte: return only campaigns with a last updated timestamp on
+            their note gte (datetime)
+        :param fields: comma separated string of fields to be filtered and returned
+            possible values are: id, dst_ip, target_domain, state, name, last_updated,
+            note, note_modified_by, note_modified_timestamp
+        :param page: page number to return (int)
+        :param page_size: number of object to return in response (int)
+        """
+        valid_keys = [
+            "fields",
+            "dst_ip",
+            "target_domain",
+            "state",
+            "name",
+            "last_updated_gte",
+            "note_modified_timestamp_gte",
+            "page",
+            "page_size",
+        ]
+
+        deprecated_keys = []
+
+        return _generate_params(args, valid_keys, deprecated_keys)
+
+    @staticmethod
+    def _generate_account_params(args):
+        """
+        Generate query parameters for accounts based provided args
+        :param args: dict of keys to generate query params
+        :rtype: dict
+        """
+        valid_keys = [
+            "all",
+            "c_score",
+            "c_score_gte",
+            "certainty",
+            "certainty_gte",
+            "fields",
+            "first_seen",
+            "include_detection_summaries",
+            "last_seen",
+            "last_source",
+            "max_id",
+            "min_id",
+            "name",
+            "note_modified_timestamp_gte",
+            "ordering",
+            "page",
+            "page_size",
+            "privilege_category",
+            "privilege_level",
+            "privilege_level_gte",
+            "state",
+            "t_score",
+            "t_score_gte",
+            "tags",
+            "threat",
+            "threat_gte",
+            "uid",
+            "last_detection_timestamp_gte",
+            "last_detection_timestamp_lte",
+        ]
+
+        deprecated_keys = []
+
+        return _generate_params(args, valid_keys, deprecated_keys)
+
+    @validate_gte_api_v2
+    def delete_account_note(self, account_id=None, note_id=None):
+        """
+        Set account note
+        :param account_id: account ID
+        :param note_id: ID of the note to delete
+        """
+
+        return self._request(
+            method="delete", url=f"{self.url}/accounts/{account_id}/notes/{note_id}"
+        )
+
+    @validate_gte_api_v2
+    def get_all_accounts(self, **kwargs):
+        """
+        Generator to retrieve all accounts - all parameters are optional
+        :param all: does nothing
+        :param c_score: certainty score (int) - will be removed with deprecation of v1 of api
+        :param c_score_gte: certainty score greater than or equal to (int) - will be removed with deprecation of v1 of api
+        :param certainty: certainty score (int)
+        :param certainty_gte: certainty score greater than or equal to (int)
+        :param fields: comma separated string of fields to be filtered and returned
+            possible values are id, url, name, state, threat, certainty, severity, account_type,
+            tags, note, note_modified_by, note_modified_timestamp, privilege_level, privilege_category,
+            last_detection_timestamp, detection_set, probable_home
+        :param first_seen: first seen timestamp of the account (datetime)
+        :param include_detection_summaries: include detection summary in response (bool)
+        :param last_seen: last seen timestamp of the account (datetime)
+        :param last_source: registered ip address of host
+        :param max_id: maximum ID of account returned
+        :param min_id: minimum ID of account returned
+        :param name: registered name of host
+        :param note_modified_timestamp_gte: note last modified timestamp greater than or equal to (datetime)
+        :param ordering: field to use to order response
+        :param page: page number to return (int)
+        :param page_size: number of object to return in response (int)
+        :param privilege_category: privilege category of account (low/medium/high)
+        :param privilege_level: privilege level of account (0-10)
+        :param privilege_level_gte: privilege of account level greater than or equal to (int)
+        :param state: state of host (active/inactive)
+        :param t_score: threat score (int) - will be removed with deprecation of v1 of api
+        :param t_score_gte: threat score greater than or equal to (int) - will be removed with deprecation of v1 of api
+        :param tags: tags assigned to account
+        :param threat: threat score (int)
+        :param threat_gte: threat score greater than or equal to (int)
+        """
+        url = f"{self.url}/accounts"
+        params = self._generate_account_params(kwargs)
+        method = "get"
+        resp = self._request(
+            method=method,
+            url=url,
+            params=params,
+        )
+        yield resp
+
+        yield from self.yield_results(resp, method, params=params)
+
+    @validate_gte_api_v2
+    # TODO remove this function if APIv < 2.2. is officially retired
+    def get_account_by_id(self, account_id=None, **kwargs):
+        """
+        Get account by id
+        :param account_id: account id - required
+        :param fields: comma separated string of fields to be filtered and returned - optional
+            possible values are id, url, name, state, threat, certainty, severity, account_type,
+            tags, note, note_modified_by, note_modified_timestamp, privilege_level, privilege_category,
+            last_detection_timestamp, detection_set, probable_home
+        """
+        if not account_id:
+            raise ValueError("Account id required")
+
+        return self._request(
+            method="get",
+            url=f"{self.url}/accounts/{account_id}",
+            params=self._generate_account_params(kwargs),
+        )
+
+    @validate_gte_api_v2
+    def get_account_note(self, account_id=None):
+        """
+        Get account notes
+        :param account_id: account ID
+        """
+        if not account_id:
+            raise ValueError("account id required")
+
+        return self._request(
+            method="get", url=f"{self.url}/accounts/{account_id}/notes"
+        )
+
+    @validate_gte_api_v2
+    def set_account_note(self, account_id=None, note=""):
+        """
+        Set account note
+        :param account_id: account ID
+        :param note: content of the note to set
+        """
+        if isinstance(note, str):
+            payload = {"note": note}
+        else:
+            raise TypeError("Note must be of type str")
+
+        return self._request(
+            method="post", url=f"{self.url}/accounts/{account_id}/notes", json=payload
+        )
+
+    @validate_gte_api_v2
+    def update_account_note(self, account_id=None, note_id=None, note=""):
+        """
+        Set account note
+        :param account_id: account ID
+        :param note_id: ID of the note to update
+        :param note: updated content of the note
+        """
+        if isinstance(note, str):
+            payload = {"note": note}
+        else:
+            raise TypeError("Note must be of type str")
+
+        return self._request(
+            method="patch",
+            url=f"{self.url}/accounts/{account_id}/notes/{note_id}",
+            json=payload,
+        )
+
+    # /assignments
+
+    @staticmethod
+    def _generate_assignment_params(args):
+        """
+        Generate query parameters for assignment queries based on provided args
+        :param args: dict of keys to generate query params
+        :rtype: dict
+        """
+        valid_keys = [
+            "accounts",
+            "assignees",
+            "created_after",
+            "fields",
+            "max_id",
+            "min_id",
+            "ordering",
+            "page",
+            "page_size",
+            "resolution",
+            "resolved",
+        ]
+
+        deprecated_keys = []
+
+        return _generate_params(args, valid_keys, deprecated_keys)
+
+    @validate_gte_api_v2
+    def create_account_assignment(self, account_id=None, user_id=None):
+        """
+        Create new assignment
+        :param assign_account_id: ID of the account to assign
+        :param assign_to_user_id: ID of the assignee
+        """
+        payload = {
+            "assign_account_id": account_id,
+            "assign_to_user_id": user_id,
+        }
+        return self._request(method="post", url=f"{self.url}/assignments", json=payload)
+
+    @validate_gte_api_v3_3
+    def create_host_assignment(self, host_id=None, user_id=None):
+        """
+        Create new assignment
+        :param assign_account_id: ID of the account to assign
+        :param assign_to_user_id: ID of the assignee
+        """
+        payload = {
+            "assign_host_id": host_id,
+            "assign_to_user_id": user_id,
+        }
+        return self._request(method="post", url=f"{self.url}/assignments", json=payload)
+
+    @validate_gte_api_v2
+    def delete_assignment(self, assignment_id=None):
+        """
+        Delete assignment
+        :param assignment_id: assignment ID
+        """
+        return self._request(
+            method="delete", url=f"{self.url}/assignments/{assignment_id}"
+        )
+
+    @validate_gte_api_v2
+    def get_all_assignments(self, **kwargs):
+        """
+        Generator to retrieve all assignments - all parameters are optional
+        :param accounts: filter by accounts ([int])
+        :param assignees: filter by assignees (int)
+        :param created_after: filter by created after timestamp
+        :param page: page number to return (int)
+        :param page_size: number of object to return in response (int)
+        :param resolution: filter by resolution (int)
+        :param resolved: filters by resolved status (bool)
+        """
+        url = f"{self.url}/assignments"
+        params = self._generate_assignment_params(kwargs)
+        method = "get"
+        resp = self._request(
+            method=method,
+            url=url,
+            params=params,
+        )
+        yield resp
+
+        # page_size only used to identify number of pages. Not a valid param.
+        params["page_size"] = len(resp.json()["results"])
+
+        yield from self.yield_results(resp, method, params=params)
+
+    @validate_gte_api_v2
+    def set_assignment_resolved(
+        self,
+        assignment_id: int,
+        detection_ids: list,
+        outcome: int,
+        note: str,
+        mark_as_fixed: bool = None,
+        triage_as: str = None,
+    ):
+        """
+        Set an assignment as resolved
+        :param outcome: integer value corresponding to the following:
+            1: benign_true_positive
+            2: malicious_true_positive
+            3: false_positive
+        :param note: Note to add to fixed/triaged detections
+        :param triage_as: One-time triage detection(s) and rename as (str).
+        :param mark_as_fixed: mark the detection(s) as fixed (bool). Custom triage_as and mark_as_fixed are mutually exclusive.
+        :param detection_ids: list of detection IDs to fix/triage
+        """
+        if not triage_as and not mark_as_fixed:
+            raise ValueError("Either triage_as or mark_as_fixed are requited")
+
+        payload = {
+            "outcome": outcome,
+            "note": note,
+            "mark_as_fixed": mark_as_fixed,
+            "triage_as": triage_as,
+            "detection_ids": detection_ids,
+        }
+        return self._request(
+            method="put",
+            url=f"{self.url}/assignments/{assignment_id}/resolve",
+            json=payload,
+        )
+
+    @validate_gte_api_v2
+    def update_assignment(self, assignment_id=None, user_id=None):
+        """
+        Update an existing assignment
+        :param assignment_id: ID of the assignment to update
+        :param assign_to_user_id: ID of the assignee
+        """
+        payload = {"assign_to_user_id": user_id}
+        return self._request(
+            method="put", url=f"{self.url}/assignments/{assignment_id}", json=payload
+        )
+
+    # /assignment_outcomes
+    @validate_gte_api_v2
+    def create_assignment_outcome(self, title: str, category: str):
+        """
+        Create a new custom Assignment Outcome
+        :param tile: title of the new Assignment Outcome to create.
+        :param category: one of benign_true_positive, malicious_true_positive or false_positive
+        """
+        if category not in [
+            "benign_true_positive",
+            "malicious_true_positive",
+            "false_positive",
+        ]:
+            raise ValueError("Invalid category provided")
+
+        payload = {"title": title, "category": category}
+        return self._request(
+            method="post", url=f"{self.url}/assignment_outcomes", json=payload
+        )
+
+    @validate_gte_api_v2
+    def delete_assignment_outcome(self, outcome_id: int):
+        """
+        Delete an existing custom Assignment Outcome
+        :param outcome_id: ID of the Assignment Outcome to delete
+        """
+        return self._request(
+            method="delete", url=f"{self.url}/assignment_outcomes/{outcome_id}"
+        )
+
+    @validate_gte_api_v2
+    def get_all_assignment_outcomes(self, **kwargs):
+        """
+        Get the outcome of a given assignment
+        :param :
+        """
+        url = f"{self.url}/assignment_outcomes"
+        method = "get"
+        resp = self._request(method=method, url=url)
+        yield resp
+
+        yield from self.yield_results(resp, method)
+
+    @validate_gte_api_v2
+    def get_assignment_outcome_by_id(self, assignment_outcome_id: int):
+        """
+        Describe an existing Assignment Outcome
+        :param assignment_outcome_id: ID of the Assignment Outcome you want details for.
+        """
+        return self._request(
+            method="get", url=f"{self.url}/assignment_outcomes/{assignment_outcome_id}"
+        )
+
+    @validate_gte_api_v2
+    def update_assignment_outcome(self, outcome_id: int, title: str, category: str):
+        """
+        Update an existing custom Assignment Outcome
+        :param outcome_id:
+        :param tile: title of the new Assignment Outcome to create.
+        :param category: one of benign_true_positive, malicious_true_positive or false_positive
+        """
+        if category not in [
+            "benign_true_positive",
+            "malicious_true_positive",
+            "false_positive",
+        ]:
+            raise ValueError("Invalid category provided")
+
+        payload = {"title": title, "category": category}
+        return self._request(
+            method="put",
+            url=f"{self.url}/assignment_outcomes/{outcome_id}",
+            json=payload,
+        )
+
+    # /audits
+
+    @validate_api_v2
+    def get_audits(self, start_date=None, end_date=None):
+        """
+        Get audits between start_date and end_date, inclusive
+        :param start_date: start date (datetime.date), GMT, defaults to date.min
+        :param end_date: end date (datetime.date), GMT, defaults to date.max
+        """
+        if start_date is None and end_date is None:
+            return self._request(method="get", url=f"{self.url}/audits")
+        elif start_date is None and end_date is not None:
+            return self._request(
+                method="get", url=f"{self.url}/audits?end={end_date.isoformat()}"
+            )
+        elif start_date is not None and end_date is None:
+            return self._request(
+                method="get", url=f"{self.url}/audits?start={start_date.isoformat()}"
+            )
+        else:
+            return self._request(
+                method="get",
+                url=f"{self.url}/audits?start={start_date.isoformat()}&end={end_date.isoformat()}",
+            )
+
+    # /campaigns
     @staticmethod
     def _generate_campaign_params(args):
         """
@@ -328,125 +804,46 @@ class VectraBaseClient(object):
 
         return _generate_params(args, valid_keys, deprecated_keys)
 
-    @staticmethod
-    def _generate_host_params(args):
+    @validate_api_v2
+    def get_all_campaigns(self, **kwargs):
         """
-        Generate query parameters for hosts based on provided args
-        :param args: dict of keys to generate query params
-        :rtype: dict
-
-        Valid params in the dict
-        :param all: if set to False, endpoint will only return hosts that have active detections, active traffic or are marked as key assets - default False
-        :param active_traffic: only return hosts that have seen traffic in the last 2 hours (bool)
-        :param c_score: certainty score (int) - will be removed with deprecation of v1 of api
-        :param c_score_gte: certainty score greater than or equal to (int) - will be removed with deprecation of v1 of api
-        :param certainty: certainty score (int)
-        :param certainty_gte: certainty score greater than or equal to (int)
-        :param fields: comma separated string of fields to be filtered and returned
-            possible values are: id,name,active_traffic,has_active_traffic,t_score,threat,c_score,
-            certainty,severity,last_source,ip,previous_ips,last_detection_timestamp,key_asset,
-            is_key_asset,state,targets_key_asset,is_targeting_key_asset,detection_set,
-            host_artifact_set,sensor,sensor_name,tags,note,note_modified_by,note_modified_timestamp,
-            url,host_url,last_modified,assigned_to,assigned_date,groups,has_custom_model,privilege_level,
-            privilege_category,probable_owner,detection_profile
-        :param has_active_traffic: host has active traffic (bool)
-        :param include_detection_summaries: include detection summary in response (bool)
-        :param is_key_asset: host is key asset (bool)
-        :param is_targeting_key_asset: host is targeting key asset (bool)
-        :param key_asset: host is key asset (bool) - will be removed with deprecation of v1 of api
-        :param last_detection_timestamp: timestamp of last detection on this host (datetime)
-        :param last_source: registered ip address modified timestamp greater than or equal to (datetime) of host
-        :param mac_address: registered mac address of host
-        :param max_id: maximum ID of host returned
-        :param min_id: minimum ID of host returned
-        :param name: registered name of host
-        :param note_modified_timestamp_gte: note last modified timestamp greater than or equal to (datetime)
-        :param ordering: field to use to order response
-        :param page: page number to return (int)
-        :param page_size: number of object to return in response (int)
-        :param privilege_category: privilege category of host (low/medium/high)
-        :param privilege_level: privilege level of host (0-10)
-        :param privilege_level_gte: privilege level of host greater than or equal to (int)
-        :param state: state of host (active/inactive)
-        :param t_score: threat score (int) - will be removed with deprecation of v1 of api
-        :param t_score_gte: threat score greater than or equal to (int) - will be removed with deprecation of v1 of api
-        :param tags: tags assigned to host
-        :param targets_key_asset: host is targeting key asset (bool)
-        :param threat: threat score (int)
-        :param threat_gte: threat score greater than or equal to (int)
+        Generator to retrieve all campaigns - all parameters are optional
+        For valid query params, see _generate_campaign_params
         """
+        resp = self._request(
+            method="get",
+            url=f"{self.url}/campaigns",
+            params=self._generate_campaign_params(kwargs),
+        )
+        yield resp
+        while resp.json()["next"]:
+            resp = self._request(method="get", url=resp.json()["next"])
+            yield resp
 
-        valid_keys = [
-            "active_traffic",
-            "all",
-            "c_score",
-            "c_score_gte",
-            "certainty",
-            "certainty_gte",
-            "fields",
-            "has_active_traffic",
-            "include_detection_summaries",
-            "is_key_asset",
-            "is_targeting_key_asset",
-            "key_asset",
-            "last_detection_timestamp",
-            "last_source",
-            "mac_address",
-            "max_id",
-            "min_id",
-            "name",
-            "note_modified_timestamp_gte",
-            "ordering",
-            "page",
-            "page_size",
-            "privilege_category",
-            "privilege_level",
-            "privilege_level_gte",
-            "state",
-            "t_score",
-            "t_score_gte",
-            "tags",
-            "targets_key_asset",
-            "threat",
-            "threat_gte",
-        ]
-
-        deprecated_keys = [
-            "c_score",
-            "c_score_gte",
-            "key_asset",
-            "t_score",
-            "t_score_gte",
-            "targets_key_asset",
-        ]
-
-        return _generate_params(args, valid_keys, deprecated_keys)
-
-    @staticmethod
-    def _generate_host_by_id_params(args):
+    @validate_api_v2
+    def get_campaign_by_id(self, campaign_id=None):
         """
-        Generate query parameters for host based on provided args
-        :param args: dict of keys to generate query params
-        :rtype: dict
-
-        Available params in the dict
-        :param host_id: host id - required
-        :param include_external: include fields regarding external connectors (e.g. CrowdStrike) - optional
-        :param include_ldap: include LDAP context pulled over AD connector - optional
-        :param fields: comma separated string of fields to be filtered and returned - optional
-            possible values are: active_traffic, assigned_date, assigned_to, c_score, campaign_summaries,
-            carbon_black, certainty, crowdstrike, detection_profile, detection_set, detection_summaries,
-            groups, has_active_traffic, has_custom_model, has_shell_knocker_learnings, host_artifact_set,
-            host_luid, host_session_luid, host_url, id, ip, is_key_asset, is_targeting_key_asset, key_asset,
-            last_detection_timestamp, last_modified, last_seen, last_source, ldap, name, note, note_modified_by,
-            note_modified_timestamp, previous_ips, privilege_category, privilege_level, probable_owner, sensor,
-            sensor_name, severity, shell_knocker, state, suspicious_admin_learnings, t_score, tags, targets_key_asset,
-            threat, url, vcenter
+        Get campaign by id
         """
-        valid_keys = ["fields", "include_external", "include_ldap"]
-        deprecated_keys = []
+        if not campaign_id:
+            raise ValueError("Campaign id required")
 
-        return _generate_params(args, valid_keys, deprecated_keys)
+        return self._request(method="get", url=f"{self.url}/campaigns/{campaign_id}")
+
+    @validate_api_v2
+    # TODO: deprecated in favor of get_all_campaigns
+    def get_campaigns(self, **kwargs):
+        """
+        Query all campaigns - all parameters are optional
+        For valid query params, see _generate_campaign_params
+        """
+        return self._request(
+            method="get",
+            url=f"{self.url}/campaigns",
+            params=self._generate_campaign_params(kwargs),
+        )
+
+    # /detections
 
     @staticmethod
     def _generate_detection_params(args):
@@ -534,383 +931,16 @@ class VectraBaseClient(object):
 
         return _generate_params(args, valid_keys, deprecated_keys)
 
-    @staticmethod
-    def _generate_group_params(args):
+    @validate_gte_api_v2
+    def delete_detection_note(self, detection_id=None, note_id=None):
         """
-        Generate query parameters for groups based on provided args
-        :param args: dict of keys to generate query params
-        :rtype: dict
-
-        Valid params in the dict
-        :param description: description of groups to search
-        :param domains: search for groups containing those domains (list)
-        :param host_ids: search for groups containing those host IDs (list)
-        :param host_names: search for groups containing those hosts (list)
-        :param last_modified_by: username of last person to modify this group
-        :param last_modified_timestamp: timestamp of last modification of group (datetime)
-        :param name: name of groups to search
-        :param page: page number to return (int)
-        :param page_size: number of object to return in response (int)
-        :param type: type of group to search (domain/host/ip)
+        Set detection note
+        :param detection_id: detection ID
+        :param note_id: ID of the note to delete
         """
-        valid_keys = [
-            "description",
-            "domains",
-            "host_ids",
-            "host_names",
-            "last_modified_by",
-            "last_modified_timestamp",
-            "name",
-            "page",
-            "page_size",
-            "type",
-        ]
-
-        deprecated_keys = []
-
-        return _generate_params(args, valid_keys, deprecated_keys)
-
-    @staticmethod
-    def _generate_rule_by_id_params(args):
-        """
-        Generate query parameters for rule based on provided args
-        :param args: dict of keys to generate query params
-        :rtype: dict
-        """
-        valid_keys = ["fields"]
-        deprecated_keys = []
-
-        return _generate_params(args, valid_keys, deprecated_keys)
-
-    @staticmethod
-    def _generate_user_params(args):
-        """
-        Generate query parameters for users based on provided args
-        :param args: dict of keys to generate query params
-        :rtype: dict
-
-        Valid params in the dict
-        :param username: filter by username
-        :param role: filter by role
-        :param account_type: filter by account type (local, ldap, radius or tacacs)
-        :param authentication_profile: filter by authentication profile
-        :param last_login_gte: filter for users that have logged in since the given timestamp
-        """
-        valid_keys = [
-            "username",
-            "role",
-            "account_type",
-            "authentication_profile",
-            "last_login_gte",
-        ]
-        deprecated_keys = []
-
-        return _generate_params(args, valid_keys, deprecated_keys)
-
-    @staticmethod
-    def _generate_ip_address_params(args):
-        """
-        Generate query parameters for ip address queries based on provided args
-        :param args: dict of keys to generate query params
-        :rtype: dict
-        """
-        valid_keys = ["include_ipv4", "include_ipv6"]
-        deprecated_keys = []
-
-        return _generate_params(args, valid_keys, deprecated_keys)
-
-    @staticmethod
-    def _generate_subnet_params(args):
-        """
-        Generate query parameters for subnet queries based on provided args
-        :param args: dict of keys to generate query params
-        :rtype: dict
-        """
-        valid_keys = ["ordering", "search"]
-        deprecated_keys = []
-
-        return _generate_params(args, valid_keys, deprecated_keys)
-
-    @staticmethod
-    def _generate_internal_network_params(args):
-        """
-        Generate query parameters for internal network queries based on provided args based on provided args
-        :param args: dict of keys to generate query params
-        :rtype: dict
-        """
-        valid_keys = ["include_ipv4", "include_ipv6"]
-        deprecated_keys = []
-
-        return _generate_params(args, valid_keys, deprecated_keys)
-
-    # Start v2 Methods
-    @validate_api_v2
-    def get_campaigns(self, **kwargs):
-        """
-        Query all campaigns - all parameters are optional
-        For valid query params, see _generate_campaign_params
-        """
-        return self._request(
-            method="get",
-            url=f"{self.url}/campaigns",
-            params=self._generate_campaign_params(kwargs),
-        )
-
-    @validate_api_v2
-    def get_all_campaigns(self, **kwargs):
-        """
-        Generator to retrieve all campaigns - all parameters are optional
-        For valid query params, see _generate_campaign_params
-        """
-        resp = self._request(
-            method="get",
-            url=f"{self.url}/campaigns",
-            params=self._generate_campaign_params(kwargs),
-        )
-        yield resp
-        while resp.json()["next"]:
-            resp = self._request(method="get", url=resp.json()["next"])
-            yield resp
-
-    @validate_api_v2
-    def get_campaign_by_id(self, campaign_id=None):
-        """
-        Get campaign by id
-        """
-        if not campaign_id:
-            raise ValueError("Campaign id required")
-
-        return self._request(method="get", url=f"{self.url}/campaigns/{campaign_id}")
-
-    # deprecated
-    @validate_api_v2
-    def get_hosts(self, **kwargs):
-        """
-        Query all hosts - all parameters are optional
-        For available query params, see _generate_host_params
-        """
-        return self._request(
-            method="get",
-            url=f"{self.url}/hosts",
-            params=self._generate_host_params(kwargs),
-        )
-
-    def get_threaded(self, url, count, **kwargs):
-        page_size = kwargs.get("params", {}).get("page_size", 5000)
-        try:
-            kwargs["params"].pop("page", None)
-        except KeyError:
-            pass
-        pages = ceil(count / page_size)
-
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=self.threads, thread_name_prefix="Get All Generator"
-        ) as executor:
-            try:
-                results = {
-                    executor.submit(
-                        self._request,
-                        method="get",
-                        url=url + f"?page={page}&page_size={page_size}",
-                        params=kwargs.get("params", {}),
-                    ): page
-                    for page in range(2, pages + 1)
-                }
-                for result in concurrent.futures.as_completed(results):
-                    yield result.result()
-            except KeyboardInterrupt:
-                executor.shutdown(wait=False, cancel_futures=True)
-
-    def yield_results(self, resp, method, **kwargs):
-        if self.threads == 1:
-            while resp.json()["next"]:
-                resp = self._request(method=method, url=resp.json()["next"])
-                yield resp
-        else:
-            count = resp.json()["count"]
-            yield from self.get_threaded(resp.url.split("?")[0], count, **kwargs)
-
-    @validate_gte_api_v3_3
-    def get_all_hosts(self, **kwargs):
-        """
-        Generator to retrieve all hosts - all parameters are optional
-        For available query params, see _generate_host_params
-        """
-        url = f"{self.url}/hosts"
-        params = self._generate_host_params(kwargs)
-        method = "get"
-        resp = self._request(
-            method=method,
-            url=url,
-            params=params,
-        )
-        yield resp
-
-        yield from self.yield_results(resp, method, params=params)
-
-    @validate_gte_api_v3_3
-    def get_host_by_id(self, host_id=None, **kwargs):
-        """
-        Get host by id
-        For available query params, see _generate_host_by_id_params
-        """
-        if not host_id:
-            raise ValueError("Host id required")
 
         return self._request(
-            method="get",
-            url=f"{self.url}/hosts/{host_id}",
-            params=self._generate_host_by_id_params(kwargs),
-        )
-
-    @validate_gte_api_v3_3
-    def set_key_asset(self, host_id=None, set=True):
-        """
-        (Un)set host as key asset
-        :param host_id: id of host needing to be set - required
-        :param set: set flag to true if setting host as key asset
-        """
-
-        if not host_id:
-            raise ValueError("Host id required")
-
-        if set:
-            payload = {"key_asset": "true"}
-        else:
-            payload = {"key_asset": "false"}
-
-        return self._request(
-            method="patch", url=f"{self.url}/hosts/{host_id}", json=payload
-        )
-
-    @validate_gte_api_v3_3
-    def get_host_tags(self, host_id=None):
-        """
-        Get host tags
-        :param host_id: ID of the host for which to retrieve the tags
-        """
-        if not host_id:
-            raise ValueError("Host id required")
-
-        return self._request(method="get", url=f"{self.url}/tagging/host/{host_id}")
-
-    @validate_gte_api_v3_3
-    def set_host_tags(self, host_id=None, tags=[], append=False):
-        """
-        Set host tags
-        :param host_id:
-        :param tags: list of tags to add to host
-        :param append: overwrites existing list if set to False, appends to existing tags if set to True
-        Set to empty list to clear tags (default: False)
-        """
-        if not host_id:
-            raise ValueError("Host id required")
-
-        if append and isinstance(tags, list):
-            current_list = self.get_host_tags(host_id=host_id).json()["tags"]
-            payload = {"tags": current_list + tags}
-        elif isinstance(tags, list):
-            payload = {"tags": tags}
-        else:
-            raise TypeError("tags must be of type list")
-
-        return self._request(
-            method="patch", url=f"{self.url}/tagging/host/{host_id}", json=payload
-        )
-
-    @validate_api_v2
-    def bulk_set_hosts_tag(self, tag, host_ids):
-        """
-        Set a tag in bulk on multiple hosts. Only one tag can be set at a time
-        :param host_ids: IDs of the hosts for which to set the tag
-        """
-        if not isinstance(host_ids, list):
-            raise TypeError("Host IDs must be of type list")
-
-        payload = {"objectIds": host_ids, "tag": tag}
-        return self._request(
-            method="post", url=f"{self.url}/tagging/host", json=payload
-        )
-
-    @validate_api_v2
-    def bulk_delete_hosts_tag(self, tag, host_ids):
-        """
-        Delete a tag in bulk on multiple hosts. Only one tag can be deleted at a time
-        :param host_ids: IDs of the hosts on which to delete the tag
-        """
-        if not isinstance(host_ids, list):
-            raise TypeError("Host IDs must be of type list")
-
-        payload = {"objectIds": host_ids, "tag": tag}
-        return self._request(
-            method="delete", url=f"{self.url}/tagging/host", json=payload
-        )
-
-    @validate_gte_api_v3_3
-    def get_host_note(self, host_id=None):
-        """
-        Get host notes
-        :param host_id:
-        For consistency we return a requests.models.Response object
-        As we do not want to return the complete host body, we alter the response content
-        """
-
-        if not host_id:
-            raise ValueError("Host id required")
-
-        host = self._request(method="get", url=f"{self.url}/hosts/{host_id}")
-        if host.status_code == 200:
-            host_note = host.json()["note"]
-            # API endpoint return HTML escaped characters
-            host_note = html.unescape(host_note) if host_note else ""
-            json_dict = {
-                "status": "success",
-                "host_id": str(host_id),
-                "note": host_note,
-            }
-            host._content = json.dumps(json_dict).encode("utf-8")
-        return host
-
-    @validate_gte_api_v3_3
-    def set_host_note(self, host_id=None, note="", append=False):
-        """
-        Set host note
-        :param host_id:
-        :param note: content of the note to set
-        :param append: overwrites existing note if set to False, appends if set to True
-        Set to empty note string to clear host note
-        """
-        if not host_id:
-            raise ValueError("Host id required")
-
-        if append and isinstance(note, str):
-            current_note = self.get_host_note(host_id=host_id).json()["note"]
-            if current_note:
-                if len(note) > 0:
-                    payload = {"note": f"{current_note}\n{note}"}
-                else:
-                    payload = {"note": current_note}
-            else:
-                payload = {"note": note}
-        elif isinstance(note, str):
-            payload = {"note": note}
-        else:
-            raise TypeError("Note must be of type str")
-        return self._request(
-            method="patch", url=f"{self.url}/hosts/{host_id}", json=payload
-        )
-
-    # deprecated
-    @validate_api_v2
-    def get_detections(self, **kwargs):
-        """
-        Query all detections - all parameters are optional
-        For valid params, see _generate_detection_params
-        """
-        return self._request(
-            method="get",
-            url=f"{self.url}/detections",
-            params=self._generate_detection_params(kwargs),
+            method="delete", url=f"{self.url}/detections/{detection_id}/notes/{note_id}"
         )
 
     @validate_gte_api_v2
@@ -954,79 +984,58 @@ class VectraBaseClient(object):
         )
 
     @validate_gte_api_v2
-    def mark_detections_fixed(self, detection_ids=None):
+    def get_detection_note(self, detection_id=None):
         """
-        Mark detections as fixed
-        :param detection_ids: list of detections to mark as fixed
+        Get detection notes
+        :param detection_id: detection ID
         """
-        if not isinstance(detection_ids, list):
-            raise ValueError("Must provide a list of detection IDs to mark as fixed")
-        return self._toggle_detections_fixed(detection_ids, fixed=True)
+        if not detection_id:
+            raise ValueError("detection id required")
 
-    @validate_gte_api_v2
-    def unmark_detections_fixed(self, detection_ids=None):
-        """
-        Unmark detections as fixed
-        :param detection_ids: list of detections to unmark as fixed
-        """
-        if not isinstance(detection_ids, list):
-            raise ValueError("Must provide a list of detection IDs to unmark as fixed")
-        return self._toggle_detections_fixed(detection_ids, fixed=False)
+        return self._request(
+            method="get", url=f"{self.url}/detections/{detection_id}/notes"
+        )
 
-    @validate_gte_api_v2
-    def _toggle_detections_fixed(self, detection_ids, fixed):
-        """
-        Internal function to mark/unmark detections as fixed
-        """
-        payload = {"detectionIdList": detection_ids, "mark_as_fixed": str(fixed)}
-
-        return self._request(method="patch", url=f"{self.url}/detections", json=payload)
-
+    @request_error_handler
     @validate_api_v2
-    def mark_detections_custom(self, detection_ids=[], triage_category=None):
+    def get_detection_pcap(self, detection_id=None, filename=None):
         """
-        Mark detections as custom
-        :param detection_ids: list of detection IDs to mark as custom
-        :param triage_category: custom name to give detection
-        :rtype: requests.Response
+        Get detection pcap
+        :param detection_id: ID of the detection for which to get a pcap
+        :param filename: filename to write the pcap to. Will be overwritten if already exists.
         """
-        if not isinstance(detection_ids, list):
-            raise ValueError("Must provide a list of detection IDs to mark as custom")
+        response = self._request(
+            method="get", url=f"{self.url}/detections/{detection_id}/pcap"
+        )
 
-        payload = {"triage_category": triage_category, "detectionIdList": detection_ids}
+        with open(filename, "wb") as f:
+            f.write(response.content)
 
-        return self._request(method="post", url=f"{self.url}/rules", json=payload)
-
-    @validate_api_v2
-    def unmark_detections_custom(self, detection_ids=[]):
-        """
-        Unmark detection as custom
-        :param detection_ids: list of detection IDs to unmark as custom
-        :rtype: requests.Response
-        """
-        if not isinstance(detection_ids, list):
-            raise ValueError("Must provide a list of detection IDs to unmark as custom")
-
-        payload = {"detectionIdList": detection_ids}
-
-        response = self._request(method="delete", url=f"{self.url}/rules", json=payload)
-
-        # DELETE returns an empty response, but we populate the response for consistency with the mark_as_fixed() function
+        # Return a <Response> object for consistency
         json_dict = {
-            "_meta": {"message": "Successfully unmarked detections", "level": "Success"}
+            "status": "success",
+            "detection_id": str(detection_id),
+            "file_created": filename,
         }
         response._content = json.dumps(json_dict).encode("utf-8")
-
         return response
 
     @validate_gte_api_v2
-    def get_detection_tags(self, detection_id=None):
+    def set_detection_note(self, detection_id=None, note=""):
         """
-        Get detection tags
-        :param detection_id:
+        Set detection note
+        :param detection_id: detection ID
+        :param note: content of the note to set
         """
+        if isinstance(note, str):
+            payload = {"note": note}
+        else:
+            raise TypeError("Note must be of type str")
+
         return self._request(
-            method="get", url=f"{self.url}/tagging/detection/{detection_id}"
+            method="post",
+            url=f"{self.url}/detections/{detection_id}/notes",
+            json=payload,
         )
 
     @validate_gte_api_v2
@@ -1054,452 +1063,83 @@ class VectraBaseClient(object):
             json=payload,
         )
 
-    @validate_api_v2
-    def bulk_set_detections_tag(self, tag, detection_ids):
-        """
-        Set a tag in bulk on multiple detections. Only one tag can be set at a time
-        :param detection_ids: IDs of the detections for which to set the tag
-        """
-        if not isinstance(detection_ids, list):
-            raise TypeError("Detection IDs must be of type list")
-
-        payload = {"objectIds": detection_ids, "tag": tag}
-        return self._request(
-            method="post", url=f"{self.url}/tagging/detection", json=payload
-        )
-
-    @validate_api_v2
-    def bulk_delete_detections_tag(self, tag, detection_ids):
-        """
-        Delete a tag in bulk on multiple detections. Only one tag can be deleted at a time
-        :param detection_ids: IDs of the detections for which to delete the tag
-        """
-        if not isinstance(detection_ids, list):
-            raise TypeError("Detection IDs must be of type list")
-
-        payload = {"objectIds": detection_ids, "tag": tag}
-        return self._request(
-            method="delete", url=f"{self.url}/tagging/detection", json=payload
-        )
-
     @validate_gte_api_v2
-    def get_detection_note(self, detection_id=None):
-        """
-        Get detection notes
-        :param detection_id:
-        For consistency we return a requests.models.Response object
-        As we do not want to return the complete detection body, we alter the response content
-        """
-        detection = self._request(
-            method="get", url=f"{self.url}/detections/{detection_id}"
-        )
-        if detection.status_code == 200:
-            detection_note = detection.json()["note"]
-            # API endpoint return HTML escaped characters
-            detection_note = html.unescape(detection_note) if detection_note else ""
-            json_dict = {
-                "status": "success",
-                "detection_id": str(detection_id),
-                "note": detection_note,
-            }
-            detection._content = json.dumps(json_dict).encode("utf-8")
-        return detection
-
-    @validate_gte_api_v2
-    def set_detection_note(self, detection_id=None, note="", append=False):
+    def update_detection_note(self, detection_id=None, note_id=None, note=""):
         """
         Set detection note
-        :param detection_id:
-        :param note: content of the note to set
-        :param append: overwrites existing note if set to False, appends if set to True
-        Set to empty note string to clear detection note
+        :param detection_id: detection ID
+        :param note_id: ID of the note to update
+        :param note: updated content of the note
         """
-        if append and isinstance(note, str):
-            current_note = self.get_detection_note(detection_id=detection_id).json()[
-                "note"
-            ]
-            if current_note:
-                if len(note) > 0:
-                    payload = {"note": f"{current_note}\n{note}"}
-                else:
-                    payload = {"note": current_note}
-            else:
-                payload = {"note": note}
-        elif isinstance(note, str):
+        if isinstance(note, str):
             payload = {"note": note}
         else:
             raise TypeError("Note must be of type str")
 
         return self._request(
-            method="patch", url=f"{self.url}/detections/{detection_id}", json=payload
+            method="patch",
+            url=f"{self.url}/detections/{detection_id}/notes/{note_id}",
+            json=payload,
         )
 
-    @request_error_handler
-    @validate_api_v2
-    def get_detection_pcap(self, detection_id=None, filename=None):
+    # /groups
+
+    @staticmethod
+    def _generate_group_params(args):
         """
-        Get detection pcap
-        :param detection_id: ID of the detection for which to get a pcap
-        :param filename: filename to write the pcap to. Will be overwritten if already exists.
+        Generate query parameters for groups based on provided args
+        :param args: dict of keys to generate query params
+        :rtype: dict
         """
-        response = self._request(
-            method="get", url=f"{self.url}/detections/{detection_id}/pcap"
-        )
-
-        with open(filename, "wb") as f:
-            f.write(response.content)
-
-        # Return a <Response> object for consistency
-        json_dict = {
-            "status": "success",
-            "detection_id": str(detection_id),
-            "file_created": filename,
-        }
-        response._content = json.dumps(json_dict).encode("utf-8")
-        return response
-
-    @request_error_handler
-    @validate_api_v2
-    def get_rules(self, name=None, rule_id=None, **kwargs):
-        """
-        Query all rules
-        For valid query params, see _generate_rule_params
-        """
-
-        deprecation(
-            "Some rules are no longer compatible with the APIv2, please switch to the APIv2.1"
-        )
-        if name:
-            deprecation(
-                'The "name" argument will be removed from this function, please use get_all_rules with the "contains" query parameter'
-            )
-            return self.get_rules_by_name(triage_category=name)
-        elif rule_id:
-            deprecation(
-                'The "rule_id" argument will be removed from this function, please use the corresponding get_rule_by_id function'
-            )
-            return self.get_rule_by_id(rule_id)
-        else:
-            return self._request(
-                method="get",
-                url=f"{self.url}/rules",
-                params=self._generate_rule_params(kwargs),
-            )
-
-    @validate_gte_api_v2
-    def get_rule_by_id(self, rule_id, **kwargs):
-        """
-        Get triage rules by id
-        :param rule_id: id of triage rule to retrieve
-        :param fields: comma separated string of fields to be filtered and returned
-            possible values are: active_detections, all_hosts, category, created_timestamp, description,
-            enabled, flex1, flex2, flex3, flex4, flex5, flex6, host, host_group, id, identity, ip,
-            ip_group, is_whitelist, last_timestamp, priority, remote1_dns, remote1_dns_groups,
-            remote1_ip, remote1_ip_groups, remote1_kerb_account, remote1_kerb_service, remote1_port,
-            remote1_proto, remote2_dns, remote2_dns_groups, remote2_ip, remote2_ip_groups, remote2_port,
-            remote2_proto, sensor_luid, smart_category, template, total_detections, type_vname, url
-        """
-        if not rule_id:
-            raise ValueError("Rule id required")
-
-        deprecation(
-            "Some rules are no longer compatible with the APIv2, please switch to the APIv2.1"
-        )
-
-        return self._request(
-            method="get",
-            url=f"{self.url}/rules/{rule_id}",
-            params=self._generate_rule_by_id_params(kwargs),
-        )
-
-    @validate_gte_api_v2
-    def get_rules_by_name(self, triage_category=None, description=None):
-        """
-        Get triage rules by name or description
-        Condition are to be read as OR
-        :param triage_category: 'Triage as' field of filter
-        :param description: Description of the triage filter
-        :rtype list: to be backwards compatible
-        """
-        search_query = triage_category if triage_category else description
-        return self.get_rules(contains=search_query)
-
-    @validate_gte_api_v2
-    def get_all_rules(self, **kwargs):
-        """
-        Generator to retrieve all rules page by page - all parameters are optional
-        For valid query params, see _generate_rule_params
-        """
-        url = f"{self.url}/rules"
-        params = self._generate_rule_params(kwargs)
-        method = "get"
-        resp = self._request(
-            method=method,
-            url=url,
-            params=params,
-        )
-        yield resp
-
-        yield from self.yield_results(resp, method, params=params)
-
-    @validate_gte_api_v2
-    def create_rule(
-        self,
-        detection_category=None,
-        detection_type=None,
-        triage_category=None,
-        is_whitelist=False,
-        **kwargs,
-    ):
-        """
-        Create triage rule
-        :param detection_category: detection category to triage [botnet activity, command & control, reconnaissance,
-        lateral movement, exfiltration]
-        :param detection_type: detection type to triage
-        :param triage_category: name that will be used for triaged detection
-        :param description: name of the triage rule
-        :param is_whitelist: set to True if rule is to whitelist; opposed to tracking detections without scores (boolean)
-        :param ip: list of ip addresses to apply to triage rule
-        :param ip_group: list of IP groups IDs to add to rule
-        :param host: list of host ids to apply to triage rule
-        :param host_group: list of Host groups IDs to add to rule
-        :param sensor_luid: list of sensor luids to triage
-        :param priority: used to determine order of triage filters (int)
-        :param all_hosts: apply triage rule to all hosts (boolean)
-        :param remote1_ip: destination IP where this Triage filter will be applied to
-        :param remote1_ip_groups: destination IP Groups where this Triage filter will be applied to
-        :param remote1_proto: destination protocol where this Triage filter will be applied to
-        :param remote1_port: destination port where this Triage filter will be applied to
-        :param remote1_dns: destination FQDN where this Triage filter will apply to
-        :param remote1_dns_groups: domain groups where this Triage filter will apply to
-        :param remote2_ip: destination IP where this Triage filter will be applied to
-        :param remote2_ip_groups: destination IP Groups where this Triage filter will be applied to
-        :param remote2_proto: destination protocol where this Triage filter will be applied to
-        :param remote2_port: destination port where this Triage filter will be applied to
-        :param remote2_dns: destination FQDN where this Triage filter will apply to
-        :param remote2_dns_groups: domain groups where this Triage filter will apply to
-        :param account: accounts where this triage filter will apply to (list)
-        :param named_pipe: (Suspicious Remote Execution) named pipes where this triage filter will apply to (list)
-        :param uuid: (Suspicious Remote Execution) UUID where this triage filter will apply to (list)
-        :param identity: (Kerberos detection) identity where this triage filter will apply to (list)
-        :param service: (PAA detections) services where this triage filter will apply to (list)
-        :param file_share: (Ransomware File Activity) file share where this triage filter will apply to - escape backslashes with "\" (list)
-        :param file_extensions: (Ransomware File Activity) file extensions where this triage filter will apply to (list)
-        :param rdp_client_name: (Suspicious Remote Desktop) RDP client name where this triage filter will apply to (list)
-        :param rdp_client_token: (Suspicious Remote Desktop) RDP client token where this triage filter will apply to (list)
-        :param keyboard_name: (Suspicious Remote Desktop) RDP keyboard name where this triage filter will apply to (list)
-        :returns request object
-        """
-        if not all([detection_category, detection_type, triage_category]):
-            raise KeyError(
-                "missing required parameter: detection_category, detection_type, triage_category"
-            )
-        if detection_category.lower() not in [
-            "botnet activity",
-            "command & control",
-            "reconnaissance",
-            "lateral movement",
-            "exfiltration",
-            "info",
-        ]:
-            raise ValueError("detection_category not recognized")
-
-        payload = {
-            "detection_category": detection_category,
-            "detection": detection_type,
-            "triage_category": triage_category,
-            "is_whitelist": is_whitelist,
-        }
-
         valid_keys = [
+            "account_ids",
+            "account_names",
             "description",
-            "is_whitelist",
-            "ip",
-            "ip_group",
-            "host",
-            "host_group",
-            "sensor_luid",
-            "priority",
-            "enabled",
-            "all_hosts",
-            "remote1_ip",
-            "remote1_ip_groups",
-            "remote1_proto",
-            "remote1_port",
-            "remote1_dns",
-            "remote1_dns_groups",
-            "remote2_ip",
-            "remote2_ip_groups",
-            "remote2_proto",
-            "remote2_port",
-            "remote2_dns",
-            "remote2_dns_groups",
-            "account",
-            "named_pipe",
-            "uuid",
-            "identity",
-            "service",
-            "file_share",
-            "file_extensions",
-            "rdp_client_name",
-            "rdp_client_token",
-            "keyboard_name",
+            "domains",
+            "host_ids",
+            "host_names",
+            "importance",
+            "ips",
+            "last_modified_by",
+            "last_modified_timestamp",
+            "membership_action",
+            "name",
+            "page",
+            "page_size",
+            "type",
         ]
 
-        for k, v in kwargs.items():
-            if k in valid_keys:
-                payload[k] = v
-            else:
-                raise ValueError(
-                    f"argument {str(k)} is an invalid field for rule creation"
-                )
+        deprecated_keys = []
 
-        return self._request(method="post", url=f"{self.url}/rules", json=payload)
+        return _generate_params(args, valid_keys, deprecated_keys)
 
-    @validate_gte_api_v2
-    def update_rule(self, rule_id=None, name=None, append=False, json=None, **kwargs):
+    @validate_gte_api_v3_2
+    def delete_group(self, group_id=None):
         """
-        Update triage rule
-        :param rule_id: id of rule to update
-        :param name: name of rule to update
-        :param append: set to True if appending to existing list (boolean)
-        :param description: name of the triage rule
-        :param is_whitelist: set to True if rule is to whitelist; opposed to tracking detections without scores (boolean)
-        :param ip: list of ip addresses to apply to triage rule
-        :param ip_group: list of IP groups IDs to add to rule
-        :param host: list of host ids to apply to triage rule
-        :param host_group: list of Host groups IDs to add to rule
-        :param sensor_luid: list of sensor luids to triage
-        :param priority: used to determine order of triage filters (int)
-        :param all_hosts: apply triage rule to all hosts (boolean)
-        :param remote1_ip: destination IP where this Triage filter will be applied to
-        :param remote1_ip_groups: destination IP Groups where this Triage filter will be applied to
-        :param remote1_proto: destination protocol where this Triage filter will be applied to
-        :param remote1_port: destination port where this Triage filter will be applied to
-        :param remote1_dns: destination FQDN where this Triage filter will apply to
-        :param remote1_dns_groups: domain groups where this Triage filter will apply to
-        :param remote2_ip: destination IP where this Triage filter will be applied to
-        :param remote2_ip_groups: destination IP Groups where this Triage filter will be applied to
-        :param remote2_proto: destination protocol where this Triage filter will be applied to
-        :param remote2_port: destination port where this Triage filter will be applied to
-        :param remote2_dns: destination FQDN where this Triage filter will apply to
-        :param remote2_dns_groups: domain groups where this Triage filter will apply to
-        :param account: accounts where this triage filter will apply to (list)
-        :param named_pipe: (Suspicious Remote Execution) named pipes where this triage filter will apply to (list)
-        :param uuid: (Suspicious Remote Execution) UUID where this triage filter will apply to (list)
-        :param identity: (Kerberos detection) identity where this triage filter will apply to (list)
-        :param service: (PAA detections) services where this triage filter will apply to (list)
-        :param file_share: (Ransomware File Activity) file share where this triage filter will apply to - escape backslashes with "\" (list)
-        :param file_extensions: (Ransomware File Activity) file extensions where this triage filter will apply to (list)
-        :param rdp_client_name: (Suspicious Remote Desktop) RDP client name where this triage filter will apply to (list)
-        :param rdp_client_token: (Suspicious Remote Desktop) RDP client token where this triage filter will apply to (list)
-        :param keyboard_name: (Suspicious Remote Desktop) RDP keyboard name where this triage filter will apply to (list)
-        :returns request object
-        """
-
-        if name:
-            deprecation(
-                'The "name" argument will be removed from this function, please use get_all_rules with the "contains" query parameter'
-            )
-            matching_rules = self.get_rules_by_name(triage_category=name)
-            if len(matching_rules) > 1:
-                raise Exception("More than one rule matching the name")
-            elif len(matching_rules) < 1:
-                raise Exception("No rule matching the search")
-            else:
-                rule = matching_rules[0]
-        elif rule_id:
-            rule = self.get_rule_by_id(rule_id=rule_id).json()
-        else:
-            raise ValueError("rule name or id must be provided")
-
-        valid_keys = [
-            "description",
-            "is_whitelist",
-            "ip",
-            "ip_group",
-            "host",
-            "host_group",
-            "sensor_luid",
-            "priority",
-            "all_hosts",
-            "remote1_ip",
-            "remote1_ip_groups",
-            "remote1_proto",
-            "remote1_port",
-            "remote1_dns",
-            "remote1_dns_groups",
-            "remote2_ip",
-            "remote2_ip_groups",
-            "remote2_proto",
-            "remote2_port",
-            "remote2_dns",
-            "remote2_dns_groups",
-            "account",
-            "named_pipe",
-            "uuid",
-            "identity",
-            "service",
-            "file_share",
-            "file_extensions",
-            "rdp_client_name",
-            "rdp_client_token",
-            "keyboard_name",
-        ]
-
-        for k, v in kwargs.items():
-            if k in valid_keys:
-                if append:
-                    if isinstance(rule[k], list):
-                        rule[k] += v
-                    else:
-                        rule[k] = v
-                else:
-                    rule[k] = v
-            else:
-                raise ValueError(f"invalid parameter provided: {str(k)}")
-
-        return self._request(
-            method="put", url=f'{self.url}/rules/{rule["id"]}', json=rule
-        )
-
-    @validate_gte_api_v2
-    def delete_rule(self, rule_id=None, restore_detections=True):
-        """
-        Delete triage rule
-        :param rule_id:
-        :param restore_detections: restore previously triaged detections (bool) default behavior is to restore
+        Delete group
+        :param group_id:
         detections
         """
-
-        if not rule_id:
-            raise ValueError("Rule id required")
-
-        params = {"restore_detections": restore_detections}
-
-        return self._request(
-            method="delete", url=f"{self.url}/rules/{rule_id}", params=params
-        )
-
-    # deprecated
-    @validate_api_v2
-    def get_groups(self, **kwargs):
-        """
-        Query all groups - all parameters are optional
-        For valid params, see _generate_group_params
-        """
-
-        return self._request(
-            method="get",
-            url=f"{self.url}/groups",
-            params=self._generate_group_params(kwargs),
-        )
+        return self._request(method="delete", url=f"{self.url}/groups/{group_id}")
 
     @validate_gte_api_v3_2
     def get_all_groups(self, **kwargs):
         """
         Generator to retrieve all groups - all parameters are optional
-        For valid params, see _generate_group_params
+        :param account_ids: search for groups containing those account IDs (list)
+        :param account_names: search for groups containing those account names (list)
+        :param description: description of groups to search
+        :param domains: search for groups containing those domains (list)
+        :param host_ids: search for groups containing those host IDs (list)
+        :param host_names: search for groups containing those hosts (list)
+        :param importance: search for groups of this specific importance (One of "high", "medium", "low", or "never_prioritize")
+        :param ips: search for groups containing those IPs (list)
+        :param last_modified_by: username of last person to modify this group
+        :param last_modified_timestamp: timestamp of last modification of group (datetime)
+        :param name: name of groups to search
+        :param page: page number to return (int) TODO check
+        :param page_size: number of object to return in response (int) TODO check
+        :param type: type of group to search (domain/host/ip)
         """
         url = f"{self.url}/groups"
         params = self._generate_group_params(kwargs)
@@ -1521,75 +1161,20 @@ class VectraBaseClient(object):
         """
         return self._request(method="get", url=f"{self.url}/groups/{group_id}")
 
-    @validate_gte_api_v3_2
-    def get_groups_by_name(self, name=None, description=None):
-        """
-        Get groups by name or description
-        :param name: Name of group #deprecated
-        :param description: Description of the group*
-        *params are to be read as OR
-        """
-        if name and description:
-            raise Exception("Can only provide a name OR a description")
-        if name:
-            response = self.get_groups(name=name)
-            return response.json()["results"]
-        elif description:
-            response = self.get_groups(description=description)
-            return response.json()["results"]
 
-    @validate_api_v2
-    def create_group(
-        self, name=None, description="", type=None, members=[], rules=[], **kwargs
-    ):
-        """
-        Create group
-        :param name: name of the group to create
-        :param description: description of the group
-        :param type: type of the group to create (domain/host/ip)
-        :param members: list of host ids to add to group
-        :param rules: list of triage rule ids to add to group
-        :rtype requests.Response:
-        """
-        if not name:
-            raise ValueError("missing required parameter: name")
-        if not type:
-            raise ValueError("missing required parameter: type")
-        if type not in ["host", "domain", "ip"]:
-            raise ValueError('parameter type must have value "domain", "ip" or "host"')
-        if not isinstance(members, list):
-            raise TypeError("members must be type: list")
-        if not isinstance(rules, list):
-            raise TypeError("rules must be type: list")
-
-        payload = {
-            "name": name,
-            "description": description,
-            "type": type,
-            "members": members,
-            "rules": rules,
-        }
-
-        for k, v in kwargs.items():
-            if not isinstance(v, list):
-                raise TypeError(f"{k} must be of type: list")
-            payload[k] = v
-
-        return self._request(method="post", url=f"{self.url}/groups", json=payload)
 
     @validate_gte_api_v3_2
     def update_group(
-        self, group_id, name=None, description=None, members=[], append=False, **kwargs
+        self, group_id, name=None, description="", members=[], append=False, **kwargs
     ):
         """
         Update group
         :param group_id: id of group to update
         :param name: name of group
         :param description: description of the group
-        :param members: list of host ids to add to group
+        :param members: list of members to add to group
         :param append: set to True if appending to existing list (boolean)
         """
-
         if not isinstance(members, list):
             raise TypeError("members must be type: list")
 
@@ -1604,6 +1189,9 @@ class VectraBaseClient(object):
             if group["type"] in ["domain", "ip"]:
                 for member in group["members"]:
                     members.append(member)
+            elif group["type"] == "account":
+                for member in group["members"]:
+                    members.append(member["uid"])
             else:
                 for member in group["members"]:
                     members.append(member["id"])
@@ -1614,413 +1202,14 @@ class VectraBaseClient(object):
         description = description if description else group["description"]
 
         payload = {"name": name, "description": description, "members": members}
+
+        for k, v in kwargs.items():
+            payload[k] = v
         return self._request(
             method="patch", url=f"{self.url}/groups/{id}", json=payload
         )
 
-    @validate_gte_api_v3_2
-    def delete_group(self, group_id=None):
-        """
-        Delete group
-        :param group_id:
-        detections
-        """
-        return self._request(method="delete", url=f"{self.url}/groups/{group_id}")
-
-    @validate_gte_api_v3_3
-    def get_all_users(self, **kwargs):
-        """
-        Generator to query all users
-        For valid params, see _generate_user_params
-        """
-        url = f"{self.url}/users"
-        params = self._generate_user_params(kwargs)
-        method = "get"
-        resp = self._request(
-            method=method,
-            url=url,
-            params=params,
-        )
-        yield resp
-
-        # page_size only used to identify number of pages. Not a valid param.
-        params["page_size"] = len(resp.json()["results"])
-
-        yield from self.yield_results(resp, method, params=params)
-
-    @validate_gte_api_v3_3
-    def get_user_by_name(self, username=None):
-        """
-        Get users by name
-        :param user: name of user to retrieve
-        """
-        if not username:
-            raise ValueError("Username required")
-
-        params = {"username": username}
-
-        return self._request(method="get", url=f"{self.url}/users", params=params)
-
-    @validate_gte_api_v3_3
-    def get_user_by_id(self, user_id=None):
-        """
-        Get users by id
-        :param user: id of user to retrieve
-        """
-        if not user_id:
-            raise ValueError("User ID required")
-
-        # params = {"username": username}
-
-        return self._request(method="get", url=f"{self.url}/users/{user_id}")
-
-    @validate_api_v2
-    def update_user(self, user_id=None, account_type=None, authentication_profile=None):
-        """
-        Update the authentication type for a user
-        :param user_id: user ID
-        :param account_type: new user account type (local, ldap, radius, tacacs)
-        :param authentication_profile: authentication profile name
-        """
-        if not user_id:
-            raise ValueError("User id required")
-
-        if account_type not in ["local", "ldap", "radius", "tacacs"]:
-            raise ValueError("Invalid account_type provided")
-
-        if account_type == "local":
-            authentication_profile is None
-        elif not authentication_profile:
-            raise ValueError("Authentication profile required")
-
-        payload = {
-            "account_type": account_type,
-            "authentication_profile": authentication_profile,
-        }
-
-        return self._request(
-            method="patch", url=f"{self.url}/users/{user_id}", json=payload
-        )
-
-    @validate_gte_api_v3_3
-    def get_proxies(self, proxy_id=None):
-        """
-        Get all defined proxies
-        """
-        if proxy_id:
-            deprecation(
-                'The "proxy_id" argument will be removed from this function, please use the get_proxy_by_id() function'
-            )
-            return self.get_proxy_by_id(proxy_id=proxy_id)
-        else:
-            return self._request(method="get", url=f"{self.url}/proxies")
-
-    @validate_gte_api_v3_3
-    def get_proxy_by_id(self, proxy_id=None):
-        """
-        Get proxy by id
-        :param proxy_id: id of proxy to retrieve - caution those are UUIDs not int
-        """
-        if not proxy_id:
-            raise ValueError("Proxy id required")
-
-        return self._request(method="get", url=f"{self.url}/proxies/{proxy_id}")
-
-    @validate_gte_api_v3_3
-    def add_proxy(self, address=None, enable=True):
-        """
-        Add a proxy to the proxy list
-        :param address: IP address of the proxy to add
-        :param enable: set to true to consider the IP as a proxy, false to never consider it as proxy
-        """
-        payload = {"proxy": {"address": address, "considerProxy": enable}}
-
-        return self._request(method="post", url=f"{self.url}/proxies", json=payload)
-
-    # TODO PATCH request modifies the proxy ID  and 404 is actually a 500 - APP-15864
-    @validate_gte_api_v3_3
-    def update_proxy(self, proxy_id=None, address=None, enable=True):
-        """
-        Update an existing proxy in the system
-        :param proxy_id: ID of the proxy to update
-        :param address: IP address to set for this proxy
-        :param enable: set to true to consider the IP as a proxy, false to never consider it as proxy
-        CAUTION: the proxy ID (resource identifier) gets modified by the PATCH request at the moment
-        CAUTION: PATCHing an invalid ID returns a HTTP 500 instead of 404 at the moment
-        """
-        if not proxy_id:
-            raise ValueError("Proxy id required")
-
-        payload = {"proxy": {}}
-        if address is not None:
-            payload["proxy"]["address"] = address
-        if enable is not None:
-            payload["proxy"]["considerProxy"] = enable
-
-        return self._request(
-            method="patch", url=f"{self.url}/proxies/{proxy_id}", json=payload
-        )
-
-    @validate_gte_api_v3_3
-    def delete_proxy(self, proxy_id=None):
-        """
-        Delete a proxy from the proxy list
-        :param proxy_id: ID of the proxy to delete
-        """
-        return self._request(method="delete", url=f"{self.url}/proxies/{proxy_id}")
-
-    @validate_gte_api_v3_3
-    def create_feed(self, name, category, certainty, itype, duration: int):
-        """
-        Creates new threat feed
-        ***Values for category, type, and certainty are case sensitive***
-        :param name: name of threat feed
-        :param category: category that detection will register. supported values are lateral, exfil, and cnc
-        :param certainty: certainty applied to detection. Supported values are Low, Medium, High
-        :param itype: indicator type - supported values are Anonymize, Exfiltration, Malware Artifacts, and Watchlist
-        :param duration: days that the threat feed will be applied
-        :returns: request object
-        """
-        category = category.lower()
-        certainty = certainty.capitalize()
-        itype = itype.capitalize()
-
-        if category not in ["lateral", "exfil", "cnc"]:
-            raise ValueError(f"Invalid category provided: {category}")
-
-        if certainty not in ["Low", "Medium", "High"]:
-            raise ValueError(f"Invalid certainty provided: {str(certainty)}")
-
-        if itype not in [
-            "Anonymize",
-            "Exfiltration",
-            "Malware Artifacts",
-            "Watchlist",
-            "C2",
-        ]:
-            raise ValueError(f"Invalid itype provided: {str(itype)}")
-
-        if not isinstance(duration, int):
-            raise ValueError(
-                "Invalid duration provided, duration must be an integer value"
-            )
-
-        payload = {
-            "threatFeed": {
-                "name": name,
-                "defaults": {
-                    "category": category,
-                    "certainty": certainty,
-                    "indicatorType": itype,
-                    "duration": duration,
-                },
-            }
-        }
-
-        return self._request(method="post", url=f"{self.url}/threatFeeds", json=payload)
-
-    @validate_gte_api_v3_3
-    def delete_feed(self, feed_id=None):
-        """
-        Deletes threat feed from Vectra
-        :param feed_id: id of threat feed
-        """
-        return self._request(method="delete", url=f"{self.url}/threatFeeds/{feed_id}")
-
-    @validate_gte_api_v2
-    def get_feeds(self):
-        """
-        Gets list of currently configured threat feeds
-        """
-        return self._request(method="get", url=f"{self.url}/threatFeeds")
-
-    @validate_gte_api_v2
-    def get_feed_by_name(self, name=None):
-        """
-        Gets configured threat feed by name
-        :param name: name of threat feed
-        """
-        try:
-            response = self._request(method="get", url=f"{self.url}/threatFeeds")
-        except requests.ConnectionError:
-            raise Exception("Unable to connect to remote host")
-
-        if response.status_code == 200:
-            for feed in response.json()["threatFeeds"]:
-                if feed != []:
-                    if feed["name"].lower() == name.lower():
-                        return feed
-                else:
-                    return {}
-        else:
-            raise HTTPException(response)
-
-    @validate_gte_api_v3_3
-    def post_stix_file(self, feed_id=None, stix_file=None):
-        """
-        Uploads STIX file to new threat feed or overwrites STIX file in existing threat feed
-        :param feed_id: id of threat feed
-        :param stix_file: stix filename
-        """
-        headers = copy.deepcopy(self.headers)
-        headers.pop("Content-Type", None)
-        return self._request(
-            method="post",
-            url=f"{self.url}/threatFeeds/{feed_id}",
-            headers=headers,
-            files={"file": open(stix_file)},
-        )
-
-    @validate_api_v2
-    def advanced_search(self, stype=None, page_size=50, query=None):
-        """
-        Advanced search
-        :param stype: search type (hosts, detections)
-        :param page_size: number of objects returned per page
-        :param advanced query (download the following guide for more details on query language
-            https://support.vectranetworks.com/hc/en-us/articles/360003225254-Search-Reference-Guide)
-        """
-        if stype not in ["hosts", "detections"]:
-            raise ValueError("Supported values for stype are hosts or detections")
-
-        if not query:
-            raise ValueError("Query parameter is required")
-
-        params = {"page_size": page_size, "query_string": query}
-
-        resp = self._request(
-            method="get", url=f"{self.url}/search/{stype}", params=params
-        )
-        yield resp
-        while resp.json()["next"]:
-            resp = self._request(method="get", url=resp.json()["next"])
-            yield resp
-
-    @validate_api_v2
-    def get_all_traffic_stats(self):
-        """
-        Generator to get all traffic stats
-        """
-        url = f"{self.url}/traffic"
-        method = "get"
-        resp = self._request(method=method, url=url)
-        yield resp
-
-        yield from self.yield_results(resp, method)
-
-    @validate_api_v2
-    def get_all_sensor_traffic_stats(self, sensor_luid=None):
-        """
-        Generator to get all traffic stats from a sensor
-        :param sensor_luid: LUID of the sensor for which to get the stats. Can be retrieved in the UI under Manage > Sensors
-        """
-        url = f"{self.url}/traffic/{sensor_luid}"
-        if not sensor_luid:
-            raise ValueError("Sensor LUID required")
-        method = "get"
-
-        resp = self._request(method=method, url=url)
-        yield resp
-
-        yield from self.yield_results(resp, method)
-
-    @validate_api_v2
-    def get_all_subnets(self, **kwargs):
-        """
-        Generator to get all subnets seen by the brain
-        :param ordering: ordering key of the results.
-            possible values are: subnet, hosts, firstSeen, lastSeen
-        :param search: only return subnets containing the search string
-        """
-        url = f"{self.url}/subnets"
-        params = self._generate_subnet_params(kwargs)
-        method = "get"
-        resp = self._request(
-            method=method,
-            url=url,
-            params=params,
-        )
-        yield resp
-
-        yield from self.yield_results(resp, method, params=params)
-
-    @validate_api_v2
-    def get_all_sensor_subnets(self, sensor_luid=None, **kwargs):
-        """
-        Generator to get all subnets seen by a sensor
-        :param sensor_luid: LUID of the sensor for which to get the subnets seen - required
-        :param ordering: ordering key of the results.
-            possible values are: subnet, hosts, firstSeen, lastSeen
-        :param search: only return subnets containing the search string
-        """
-        if not sensor_luid:
-            raise ValueError("Sensor LUID required")
-
-        url = f"{self.url}/subnets/{sensor_luid}"
-        params = self._generate_subnet_params(kwargs)
-        method = "get"
-        resp = self._request(
-            method=method,
-            url=url,
-            params=params,
-        )
-        yield resp
-
-        yield from self.yield_results(resp, method, params=params)
-
-    @validate_api_v2
-    def get_ip_addresses(self, **kwargs):
-        """
-        Get all active IPs seen by the brain
-        CAUTION: this is not a generator
-        :param include_ipv4: Include IPv4 addresses - default True
-        :param include_ipv6: Include IPv6 addresses - default True
-        """
-        return self._request(
-            method="get",
-            url=f"{self.url}/ip_addresses",
-            params=self._generate_ip_address_params(kwargs),
-        )
-
-    @validate_api_v2
-    def get_internal_networks(self):
-        """
-        Get all internal networks configured on the brain
-        """
-        return self._request(method="get", url=f"{self.url}/settings/internal_network")
-
-    @validate_api_v2
-    def set_internal_networks(self, include=[], exclude=[], drop=[], append=True):
-        """
-        Set internal networks configured on the brain
-        :param include: list of subnets to add the internal subnets list
-        :param exclude: list of subnets to exclude from the internal subnets list
-        :param drop: list of subnets to add to the drop list
-        :param append: overwrites existing lists if set to False, appends to existing lists if set to True
-        """
-        # Check that all provided ranges are valid
-        all(ipaddress.ip_network(i) for i in include + exclude + drop)
-
-        if append and all(isinstance(i, list) for i in [include, exclude, drop]):
-            current_list = self.get_internal_networks().json()
-            # We must make all entries unique
-            payload = {
-                "include": list(
-                    set(include).union(set(current_list["included_subnets"]))
-                ),
-                "exclude": list(
-                    set(exclude).union(set(current_list["excluded_subnets"]))
-                ),
-                "drop": list(set(drop).union(set(current_list["dropped_subnets"]))),
-            }
-        elif all(isinstance(i, list) for i in [include, exclude, drop]):
-            payload = {"include": include, "exclude": exclude, "drop": drop}
-        else:
-            raise TypeError("subnets must be of type list")
-
-        return self._request(
-            method="post", url=f"{self.url}/settings/internal_network", json=payload
-        )
+    # /health
 
     @validate_gte_api_v3_3
     def get_health_check(self, check=None, cache=True, vlans=True):
@@ -2054,54 +1243,98 @@ class VectraBaseClient(object):
                 raise ValueError("Invalid check argument")
             return self._request(method="get", url=f"{self.url}/health/{check}")
 
-
-class VectraClientV2_1(VectraBaseClient):
-    VERSION3 = None
-    VERSION2 = 2.1
-    VERSION1 = None
-
-    def __init__(
-        self,
-        user=None,
-        password=None,
-        token=None,
-        url=None,
-        client_id=None,
-        secret_key=None,
-        verify=False,
-    ):
-        """
-        Initialize Vectra client
-        :param url: IP or hostname of Vectra brain (ex https://www.example.com) - required
-        :param token: API token for authentication when using API v2*
-        :param verify: Verify SSL (default: False) - optional
-        """
-        super().__init__(
-            url=url,
-            client_id=client_id,
-            secret_key=secret_key,
-            token=token,
-            verify=verify,
-        )
-
+    # /hosts
     @staticmethod
-    def _generate_account_params(args):
+    def _generate_host_by_id_params(args):
         """
-        Generate query parameters for accounts based provided args
+        Generate query parameters for host based on provided args
         :param args: dict of keys to generate query params
         :rtype: dict
+
+        Available params in the dict
+        :param host_id: host id - required
+        :param include_external: include fields regarding external connectors (e.g. CrowdStrike) - optional
+        :param include_ldap: include LDAP context pulled over AD connector - optional
+        :param fields: comma separated string of fields to be filtered and returned - optional
+            possible values are: active_traffic, assigned_date, assigned_to, c_score, campaign_summaries,
+            carbon_black, certainty, crowdstrike, detection_profile, detection_set, detection_summaries,
+            groups, has_active_traffic, has_custom_model, has_shell_knocker_learnings, host_artifact_set,
+            host_luid, host_session_luid, host_url, id, ip, is_key_asset, is_targeting_key_asset, key_asset,
+            last_detection_timestamp, last_modified, last_seen, last_source, ldap, name, note, note_modified_by,
+            note_modified_timestamp, previous_ips, privilege_category, privilege_level, probable_owner, sensor,
+            sensor_name, severity, shell_knocker, state, suspicious_admin_learnings, t_score, tags, targets_key_asset,
+            threat, url, vcenter
+        """
+        valid_keys = ["fields", "include_external", "include_ldap"]
+        deprecated_keys = []
+
+        return _generate_params(args, valid_keys, deprecated_keys)
+
+    @staticmethod
+    def _generate_host_params(args):
+        """
+        Generate query parameters for hosts based on provided args
+        :param args: dict of keys to generate query params
+        :rtype: dict
+
+        Valid params in the dict
+        :param all: if set to False, endpoint will only return hosts that have active detections, active traffic or are marked as key assets - default False
+        :param active_traffic: only return hosts that have seen traffic in the last 2 hours (bool)
+        :param c_score: certainty score (int) - will be removed with deprecation of v1 of api
+        :param c_score_gte: certainty score greater than or equal to (int) - will be removed with deprecation of v1 of api
+        :param certainty: certainty score (int)
+        :param certainty_gte: certainty score greater than or equal to (int)
+        :param fields: comma separated string of fields to be filtered and returned
+            possible values are: id,name,active_traffic,has_active_traffic,t_score,threat,c_score,
+            certainty,severity,last_source,ip,previous_ips,last_detection_timestamp,key_asset,
+            is_key_asset,state,targets_key_asset,is_targeting_key_asset,detection_set,
+            host_artifact_set,sensor,sensor_name,tags,note,note_modified_by,note_modified_timestamp,
+            url,host_url,last_modified,assigned_to,assigned_date,groups,has_custom_model,privilege_level,
+            privilege_category,probable_owner,detection_profile
+        :param has_active_traffic: host has active traffic (bool)
+        :param include_detection_summaries: include detection summary in response (bool)
+        :param is_key_asset: host is key asset (bool)
+        :param is_targeting_key_asset: host is targeting key asset (bool)
+        :param key_asset: host is key asset (bool) - will be removed with deprecation of v1 of api
+        :param last_detection_timestamp: timestamp of last detection on this host (datetime)
+        :param last_source: registered ip address modified timestamp greater than or equal to (datetime) of host
+        :param mac_address: registered mac address of host
+        :param max_id: maximum ID of host returned
+        :param min_id: minimum ID of host returned
+        :param name: registered name of host
+        :param note_modified_timestamp_gte: note last modified timestamp greater than or equal to (datetime)
+        :param ordering: field to use to order response
+        :param page: page number to return (int)
+        :param page_size: number of object to return in response (int)
+        :param privilege_category: privilege category of host (low/medium/high)
+        :param privilege_level: privilege level of host (0-10)
+        :param privilege_level_gte: privilege level of host greater than or equal to (int)
+        :param state: state of host (active/inactive)
+        :param t_score: threat score (int) - will be removed with deprecation of v1 of api
+        :param t_score_gte: threat score greater than or equal to (int) - will be removed with deprecation of v1 of api
+        :param tags: tags assigned to host
+        :param targets_key_asset: host is targeting key asset (bool)
+        :param threat: threat score (int)
+        :param threat_gte: threat score greater than or equal to (int)
+        :param last_detection_timestamp_gte: filter by last_detection_timestamp >= timestamp provided
+        :param last_detection_timestamp_lte: filter by last_detection_timestamp <= timestamp provided
         """
         valid_keys = [
+            "active_traffic",
             "all",
             "c_score",
             "c_score_gte",
             "certainty",
             "certainty_gte",
             "fields",
-            "first_seen",
+            "has_active_traffic",
             "include_detection_summaries",
-            "last_seen",
+            "is_key_asset",
+            "is_targeting_key_asset",
+            "key_asset",
+            "last_detection_timestamp",
             "last_source",
+            "mac_address",
             "max_id",
             "min_id",
             "name",
@@ -2116,40 +1349,244 @@ class VectraClientV2_1(VectraBaseClient):
             "t_score",
             "t_score_gte",
             "tags",
+            "targets_key_asset",
             "threat",
             "threat_gte",
-            "uid",
+            "last_detection_timestamp_gte",
+            "last_detection_timestamp_lte",
+        ]
+        deprecated_keys = [
+            "c_score",
+            "c_score_gte",
+            "key_asset",
+            "t_score",
+            "t_score_gte",
+            "targets_key_asset",
         ]
 
+        return _generate_params(args, valid_keys, deprecated_keys)
+
+    @validate_gte_api_v3_3
+    def delete_host_note(self, host_id=None, note_id=None):
+        """
+        Set host note
+        :param host_id: host ID
+        :param note_id: ID of the note to delete
+        """
+
+        return self._request(
+            method="delete", url=f"{self.url}/hosts/{host_id}/notes/{note_id}"
+        )
+
+    @validate_gte_api_v3_3
+    def get_all_hosts(self, **kwargs):
+        """
+        Generator to retrieve all hosts - all parameters are optional
+        For available query params, see _generate_host_params
+        """
+        url = f"{self.url}/hosts"
+        params = self._generate_host_params(kwargs)
+        method = "get"
+        resp = self._request(
+            method=method,
+            url=url,
+            params=params,
+        )
+        yield resp
+
+        yield from self.yield_results(resp, method, params=params)
+
+    @validate_gte_api_v3_3
+    def get_host_by_id(self, host_id=None, **kwargs):
+        """
+        Get host by id
+        For available query params, see _generate_host_by_id_params
+        """
+        if not host_id:
+            raise ValueError("Host id required")
+
+        return self._request(
+            method="get",
+            url=f"{self.url}/hosts/{host_id}",
+            params=self._generate_host_by_id_params(kwargs),
+        )
+
+    @validate_gte_api_v3_3
+    def get_host_note(self, host_id=None):
+        """
+        Get host notes
+        :param host_id: host ID
+        """
+        if not host_id:
+            raise ValueError("Host id required")
+
+        return self._request(method="get", url=f"{self.url}/hosts/{host_id}/notes")
+
+    @validate_gte_api_v3_3
+    def get_host_tags(self, host_id=None):
+        """
+        Get host tags
+        :param host_id: ID of the host for which to retrieve the tags
+        """
+        if not host_id:
+            raise ValueError("Host id required")
+
+        return self._request(method="get", url=f"{self.url}/tagging/host/{host_id}")
+
+    @validate_gte_api_v3_3
+    def set_host_note(self, host_id=None, note=""):
+        """
+        Set host note
+        :param host_id: host ID
+        :param note: content of the note to set
+        """
+        if isinstance(note, str):
+            payload = {"note": note}
+        else:
+            raise TypeError("Note must be of type str")
+
+        return self._request(
+            method="post", url=f"{self.url}/hosts/{host_id}/notes", json=payload
+        )
+
+    @validate_gte_api_v3_3
+    def set_host_tags(self, host_id=None, tags=[], append=False):
+        """
+        Set host tags
+        :param host_id:
+        :param tags: list of tags to add to host
+        :param append: overwrites existing list if set to False, appends to existing tags if set to True
+        Set to empty list to clear tags (default: False)
+        """
+        if not host_id:
+            raise ValueError("Host id required")
+
+        if append and isinstance(tags, list):
+            current_list = self.get_host_tags(host_id=host_id).json()["tags"]
+            payload = {"tags": current_list + tags}
+        elif isinstance(tags, list):
+            payload = {"tags": tags}
+        else:
+            raise TypeError("tags must be of type list")
+
+        return self._request(
+            method="patch", url=f"{self.url}/tagging/host/{host_id}", json=payload
+        )
+
+    @validate_gte_api_v3_3
+    def set_key_asset(self, host_id=None, set=True):
+        """
+        (Un)set host as key asset
+        :param host_id: id of host needing to be set - required
+        :param set: set flag to true if setting host as key asset
+        """
+
+        if not host_id:
+            raise ValueError("Host id required")
+
+        if set:
+            payload = {"key_asset": "true"}
+        else:
+            payload = {"key_asset": "false"}
+
+        return self._request(
+            method="patch", url=f"{self.url}/hosts/{host_id}", json=payload
+        )
+
+    @validate_gte_api_v3_3
+    def update_host_note(self, host_id=None, note_id=None, note=""):
+        """
+        Set host note
+        :param host_id: host ID
+        :param note_id: ID of the note to update
+        :param note: updated content of the note
+        """
+        if isinstance(note, str):
+            payload = {"note": note}
+        else:
+            raise TypeError("Note must be of type str")
+
+        return self._request(
+            method="patch",
+            url=f"{self.url}/hosts/{host_id}/notes/{note_id}",
+            json=payload,
+        )
+
+    # /ip_addresses
+
+    @staticmethod
+    def _generate_ip_address_params(args):
+        """
+        Generate query parameters for ip address queries based on provided args
+        :param args: dict of keys to generate query params
+        :rtype: dict
+        """
+        valid_keys = ["include_ipv4", "include_ipv6"]
         deprecated_keys = []
 
         return _generate_params(args, valid_keys, deprecated_keys)
 
-    @staticmethod
-    def _generate_detect_usage_params(args):
+    @validate_api_v2
+    def get_ip_addresses(self, **kwargs):
         """
-        Generate query parameters for detect usage query based on provided args
+        Get all active IPs seen by the brain
+        CAUTION: this is not a generator
+        :param include_ipv4: Include IPv4 addresses - default True
+        :param include_ipv6: Include IPv6 addresses - default True
+        """
+        return self._request(
+            method="get",
+            url=f"{self.url}/ip_addresses",
+            params=self._generate_ip_address_params(kwargs),
+        )
+
+    # /lockdown
+
+    @validate_api_v2
+    def get_locked_accounts(self):
+        """
+        Get list of account locked by Account Lockdown
+        """
+        return self._request(method="get", url=f"{self.url}/lockdown/account")
+
+    # /proxies
+
+    @validate_gte_api_v3_3
+    def get_proxies(self, proxy_id=None):
+        """
+        Get all defined proxies
+        """
+        if proxy_id:
+            deprecation(
+                'The "proxy_id" argument will be removed from this function, please use the get_proxy_by_id() function'
+            )
+            return self.get_proxy_by_id(proxy_id=proxy_id)
+        else:
+            return self._request(method="get", url=f"{self.url}/proxies")
+
+    @validate_gte_api_v3_3
+    def get_proxy_by_id(self, proxy_id=None):
+        """
+        Get proxy by id
+        :param proxy_id: id of proxy to retrieve - caution those are UUIDs not int
+        """
+        if not proxy_id:
+            raise ValueError("Proxy id required")
+
+        return self._request(method="get", url=f"{self.url}/proxies/{proxy_id}")
+
+    # /rules
+    @staticmethod
+    def _generate_rule_by_id_params(args):
+        """
+        Generate query parameters for rule based on provided args
         :param args: dict of keys to generate query params
         :rtype: dict
         """
-        params = {}
-        search = re.compile("[0-9]{4}-[0-9]{2}")
-        valid_keys = ["start", "end"]
-        for k, v in args.items():
-            if k in valid_keys:
-                if v is not None:
-                    # We validate the parameters here as the error thrown by the endpoint is not very verbose
-                    if search.match(v):
-                        params[k] = v
-                    else:
-                        raise ValueError(
-                            f"{str(v)} is not a valid date string for detect usage query"
-                        )
-            else:
-                raise ValueError(
-                    f"argument {str(k)} is an invalid detect usage query parameter"
-                )
-        return params
+        valid_keys = ["fields"]
+        deprecated_keys = []
+
+        return _generate_params(args, valid_keys, deprecated_keys)
 
     @staticmethod
     def _generate_rule_params(args):
@@ -2170,251 +1607,6 @@ class VectraClientV2_1(VectraBaseClient):
         deprecated_keys = []
 
         return _generate_params(args, valid_keys, deprecated_keys)
-
-    def get_campaigns(self, **kwargs):
-        raise DeprecationWarning(
-            "This function has been deprecated in the Vectra API client v2.1. Please use get_all_campaigns() which supports pagination"
-        )
-
-    def get_hosts(self, **kwargs):
-        raise DeprecationWarning(
-            "This function has been deprecated in the Vectra API client v2.1. Please use get_all_hosts() which supports pagination"
-        )
-
-    def get_detections(self, **kwargs):
-        raise DeprecationWarning(
-            "This function has been deprecated in the Vectra API client v2.1. Please use get_all_detections() which supports pagination"
-        )
-
-    @validate_gte_api_v2
-    def get_all_accounts(self, **kwargs):
-        """
-        Generator to retrieve all accounts - all parameters are optional
-        :param all: does nothing
-        :param c_score: certainty score (int) - will be removed with deprecation of v1 of api
-        :param c_score_gte: certainty score greater than or equal to (int) - will be removed with deprecation of v1 of api
-        :param certainty: certainty score (int)
-        :param certainty_gte: certainty score greater than or equal to (int)
-        :param fields: comma separated string of fields to be filtered and returned
-            possible values are id, url, name, state, threat, certainty, severity, account_type,
-            tags, note, note_modified_by, note_modified_timestamp, privilege_level, privilege_category,
-            last_detection_timestamp, detection_set, probable_home
-        :param first_seen: first seen timestamp of the account (datetime)
-        :param include_detection_summaries: include detection summary in response (bool)
-        :param last_seen: last seen timestamp of the account (datetime)
-        :param last_source: registered ip address of host
-        :param max_id: maximum ID of account returned
-        :param min_id: minimum ID of account returned
-        :param name: registered name of host
-        :param note_modified_timestamp_gte: note last modified timestamp greater than or equal to (datetime)
-        :param ordering: field to use to order response
-        :param page: page number to return (int)
-        :param page_size: number of object to return in response (int)
-        :param privilege_category: privilege category of account (low/medium/high)
-        :param privilege_level: privilege level of account (0-10)
-        :param privilege_level_gte: privilege of account level greater than or equal to (int)
-        :param state: state of host (active/inactive)
-        :param t_score: threat score (int) - will be removed with deprecation of v1 of api
-        :param t_score_gte: threat score greater than or equal to (int) - will be removed with deprecation of v1 of api
-        :param tags: tags assigned to account
-        :param threat: threat score (int)
-        :param threat_gte: threat score greater than or equal to (int)
-        """
-        url = f"{self.url}/accounts"
-        params = self._generate_account_params(kwargs)
-        method = "get"
-        resp = self._request(
-            method=method,
-            url=url,
-            params=params,
-        )
-        yield resp
-
-        yield from self.yield_results(resp, method, params=params)
-
-    @validate_gte_api_v2
-    def get_account_by_id(self, account_id=None, **kwargs):
-        """
-        Get account by id
-        :param account_id: account id - required
-        :param fields: comma separated string of fields to be filtered and returned - optional
-            possible values are id, url, name, state, threat, certainty, severity, account_type,
-            tags, note, note_modified_by, note_modified_timestamp, privilege_level, privilege_category,
-            last_detection_timestamp, detection_set, probable_home
-        """
-        raise DeprecationWarning("This method is deprecated. Use API Version > 2.2")
-
-    @validate_gte_api_v2
-    def get_account_tags(self, account_id=None):
-        """
-        Get Account tags
-        :param account_id: ID of the account for which to retrieve the tags
-        """
-        return self._request(
-            method="get", url=f"{self.url}/tagging/account/{account_id}"
-        )
-
-    @validate_gte_api_v2
-    def set_account_tags(self, account_id=None, tags=[], append=False):
-        """
-        Set account tags
-        :param account_id: ID of the account for which to set the tags
-        :param tags: list of tags to add to account
-        :param append: overwrites existing list if set to False, appends to existing tags if set to True
-        Set to empty list to clear tags (default: False)
-        """
-        if append and isinstance(tags, list):
-            current_list = self.get_account_tags(account_id=account_id).json()["tags"]
-            payload = {"tags": current_list + tags}
-        elif isinstance(tags, list):
-            payload = {"tags": tags}
-        else:
-            raise TypeError("tags must be of type list")
-
-        return self._request(
-            method="patch", url=f"{self.url}/tagging/account/{account_id}", json=payload
-        )
-
-    @validate_api_v2
-    def bulk_set_accounts_tag(self, tag, account_ids):
-        """
-        Set a tag in bulk on multiple accounts. Only one tag can be set at a time
-        Note that account IDs in APIv2.1 are not the same IDs as seen in the UI
-        :param account_ids: IDs of the accounts for which to set the tag
-        """
-        if not isinstance(account_ids, list):
-            raise TypeError("account IDs must be of type list")
-
-        payload = {"objectIds": account_ids, "tag": tag}
-        return self._request(
-            method="post", url=f"{self.url}/tagging/account", json=payload
-        )
-
-    @request_error_handler
-    @validate_api_v2
-    def bulk_delete_accounts_tag(self, tag, account_ids):
-        """
-        Delete a tag in bulk on multiple accounts. Only one tag can be deleted at a time
-        Note that account IDs in APIv2.1 are not the same IDs as seen in the UI
-        :param account_ids: IDs of the accounts on which to delete the tag
-        """
-        if not isinstance(account_ids, list):
-            raise TypeError("account IDs must be of type list")
-
-        payload = {"objectIds": account_ids, "tag": tag}
-        return self._request(
-            method="delete", url=f"{self.url}/tagging/account", json=payload
-        )
-
-    @validate_gte_api_v2
-    def get_account_note(self, account_id=None):
-        """
-        Get account notes
-        :param account_id: ID of the account for which to retrieve the note
-        For consistency we return a requests.models.Response object
-        As we do not want to return the complete host body, we alter the response content
-        """
-        account = self.get_account_by_id(account_id=account_id)
-        if account.status_code == 200:
-            account_note = account.json()["note"]
-            # API endpoint return HTML escaped characters
-            account_note = html.unescape(account_note) if account_note else ""
-            json_dict = {
-                "status": "success",
-                "account_id": str(account_id),
-                "note": account_note,
-            }
-            account._content = json.dumps(json_dict).encode("utf-8")
-        return account
-
-    @validate_api_v2
-    def get_locked_accounts(self):
-        """
-        Get list of account locked by Account Lockdown
-        """
-        return self._request(method="get", url=f"{self.url}/lockdown/account")
-
-    def get_rules(self, **kwargs):
-        raise DeprecationWarning(
-            "This function has been deprecated in the Vectra API client v2.1. Please use get_all_rules() which supports pagination"
-        )
-
-    @validate_api_v2
-    def advanced_search(self, stype=None, page_size=50, query=None):
-        """
-        Advanced search
-        :param stype: search type (hosts, detections, accounts)
-        :param page_size: number of objects returned per page
-        :param advanced query (download the following guide for more details on query language
-            https://support.vectranetworks.com/hc/en-us/articles/360003225254-Search-Reference-Guide)
-        """
-        if stype not in ["hosts", "detections", "accounts"]:
-            raise ValueError(
-                "Supported values for stype are hosts, detections or accounts"
-            )
-
-        if not query:
-            raise ValueError("Query parameter is required")
-
-        params = {"page_size": page_size, "query_string": query}
-
-        resp = self._request(
-            method="get", url=f"{self.url}/search/{stype}", params=params
-        )
-        yield resp
-        while resp.json()["next"]:
-            resp = self._request(method="get", url=resp.json()["next"])
-            yield resp
-
-    @validate_gte_api_v2
-    def get_rule_by_id(self, rule_id, **kwargs):
-        """
-        Get triage rules by id
-        :param rule_id: id of triage rule to retrieve
-        :param fields: comma separated string of fields to be filtered and returned
-            possible values are: active_detections, additional_conditions, created_timestamp,
-            description, detection, detection_category, enabled, id, is_whitelist, last_timestamp,
-            priority, source_conditions, template, total_detections, triage_category, url
-        """
-        if not rule_id:
-            raise ValueError("Rule id required")
-
-        return self._request(
-            method="get",
-            url=f"{self.url}/rules/{rule_id}",
-            params=self._generate_rule_by_id_params(kwargs),
-        )
-
-    def get_rules_by_name(self, triage_category=None, description=None):
-        raise DeprecationWarning(
-            'This function has been deprecated in the Vectra API client v2.1. Please use get_all_rules with the "contains" query parameter'
-        )
-
-    @validate_gte_api_v2
-    def get_all_rules(self, **kwargs):
-        """
-        Generator to retrieve all rules page by page - all parameters are optional
-        :param contains: search for rules containing this string (substring matching)
-        :param fields: comma separated string of fields to be filtered and returned
-            possible values are: active_detections, additional_conditions, created_timestamp,
-            description, detection, detection_category, enabled, id, is_whitelist, last_timestamp,
-            priority, source_conditions, template, total_detections, triage_category, url
-        :param include_templates: include rule templates, default is False
-        :param ordering: field used to sort response
-        :param page: page number to return (int)
-        :param page_size: number of object to return in response (int)
-        """
-        url = f"{self.url}/rules"
-        params = self._generate_rule_params(kwargs)
-        method = "get"
-        resp = self._request(
-            method=method,
-            url=url,
-            params=params,
-        )
-        yield resp
-
-        yield from self.yield_results(resp, method, params=params)
 
     @validate_gte_api_v2
     def create_rule(
@@ -2523,6 +1715,166 @@ class VectraClientV2_1(VectraBaseClient):
 
         return self._request(method="post", url=f"{self.url}/rules", json=payload)
 
+    @validate_gte_api_v2
+    def delete_rule(self, rule_id=None, restore_detections=True):
+        """
+        Delete triage rule
+        :param rule_id:
+        :param restore_detections: restore previously triaged detections (bool) default behavior is to restore
+        detections
+        """
+
+        if not rule_id:
+            raise ValueError("Rule id required")
+
+        params = {"restore_detections": restore_detections}
+
+        return self._request(
+            method="delete", url=f"{self.url}/rules/{rule_id}", params=params
+        )
+
+    @validate_gte_api_v2
+    def get_all_rules(self, **kwargs):
+        """
+        Generator to retrieve all rules page by page - all parameters are optional
+        :param contains: search for rules containing this string (substring matching)
+        :param fields: comma separated string of fields to be filtered and returned
+            possible values are: active_detections, additional_conditions, created_timestamp,
+            description, detection, detection_category, enabled, id, is_whitelist, last_timestamp,
+            priority, source_conditions, template, total_detections, triage_category, url
+        :param include_templates: include rule templates, default is False
+        :param ordering: field used to sort response
+        :param page: page number to return (int)
+        :param page_size: number of object to return in response (int)
+        """
+        url = f"{self.url}/rules"
+        params = self._generate_rule_params(kwargs)
+        method = "get"
+        resp = self._request(
+            method=method,
+            url=url,
+            params=params,
+        )
+        yield resp
+
+        yield from self.yield_results(resp, method, params=params)
+
+    @validate_gte_api_v2
+    def get_rule_by_id(self, rule_id, **kwargs):
+        """
+        Get triage rules by id
+        :param rule_id: id of triage rule to retrieve
+        :param fields: comma separated string of fields to be filtered and returned
+            possible values are: active_detections, additional_conditions, created_timestamp,
+            description, detection, detection_category, enabled, id, is_whitelist, last_timestamp,
+            priority, source_conditions, template, total_detections, triage_category, url
+        """
+        if not rule_id:
+            raise ValueError("Rule id required")
+
+        return self._request(
+            method="get",
+            url=f"{self.url}/rules/{rule_id}",
+            params=self._generate_rule_by_id_params(kwargs),
+        )
+
+    @request_error_handler
+    @validate_api_v2
+    def get_rules(self, name=None, rule_id=None, **kwargs):
+        """
+        Query all rules
+        For valid query params, see _generate_rule_params
+        """
+
+        deprecation(
+            "Some rules are no longer compatible with the APIv2, please switch to the APIv2.1"
+        )
+        if name:
+            deprecation(
+                'The "name" argument will be removed from this function, please use get_all_rules with the "contains" query parameter'
+            )
+            return self.get_rules_by_name(triage_category=name)
+        elif rule_id:
+            deprecation(
+                'The "rule_id" argument will be removed from this function, please use the corresponding get_rule_by_id function'
+            )
+            return self.get_rule_by_id(rule_id)
+        else:
+            return self._request(
+                method="get",
+                url=f"{self.url}/rules",
+                params=self._generate_rule_params(kwargs),
+            )
+
+    @validate_gte_api_v2
+    def get_rules_by_name(self, triage_category=None, description=None):
+        """
+        Get triage rules by name or description
+        Condition are to be read as OR
+        :param triage_category: 'Triage as' field of filter
+        :param description: Description of the triage filter
+        :rtype list: to be backwards compatible
+        """
+        search_query = triage_category if triage_category else description
+        return self.get_rules(contains=search_query)
+
+    @validate_api_v2
+    def mark_detections_custom(self, detection_ids=[], triage_category=None):
+        """
+        Mark detections as custom
+        :param detection_ids: list of detection IDs to mark as custom
+        :param triage_category: custom name to give detection
+        :rtype: requests.Response
+        """
+        if not isinstance(detection_ids, list):
+            raise ValueError("Must provide a list of detection IDs to mark as custom")
+
+        payload = {"triage_category": triage_category, "detectionIdList": detection_ids}
+
+        return self._request(method="post", url=f"{self.url}/rules", json=payload)
+
+    @validate_api_v2
+    def unmark_detections_custom(self, detection_ids=[]):
+        """
+        Unmark detection as custom
+        :param detection_ids: list of detection IDs to unmark as custom
+        :rtype: requests.Response
+        """
+        if not isinstance(detection_ids, list):
+            raise ValueError("Must provide a list of detection IDs to unmark as custom")
+
+        payload = {"detectionIdList": detection_ids}
+
+        response = self._request(method="delete", url=f"{self.url}/rules", json=payload)
+
+        # DELETE returns an empty response, but we populate the response for consistency with the mark_as_fixed() function
+        json_dict = {
+            "_meta": {"message": "Successfully unmarked detections", "level": "Success"}
+        }
+        response._content = json.dumps(json_dict).encode("utf-8")
+
+        return response
+
+    @validate_gte_api_v2
+    def mark_detections_fixed(self, detection_ids=None):
+        """
+        Mark detections as fixed
+        :param detection_ids: list of detections to mark as fixed
+        """
+        if not isinstance(detection_ids, list):
+            raise ValueError("Must provide a list of detection IDs to mark as fixed")
+        return self._toggle_detections_fixed(detection_ids, fixed=True)
+
+    @validate_gte_api_v2
+    def unmark_detections_fixed(self, detection_ids=None):
+        """
+        Unmark detections as fixed
+        :param detection_ids: list of detections to unmark as fixed
+        """
+        if not isinstance(detection_ids, list):
+            raise ValueError("Must provide a list of detection IDs to unmark as fixed")
+        return self._toggle_detections_fixed(detection_ids, fixed=False)
+
     def update_rule(
         self,
         rule_id=None,
@@ -2621,508 +1973,7 @@ class VectraClientV2_1(VectraBaseClient):
 
         return self._request(method="put", url=f"{self.url}/rules/{rule_id}", json=rule)
 
-    @validate_gte_api_v3_2
-    def get_groups(self, **kwargs):
-        raise DeprecationWarning(
-            "This function has been deprecated in the Vectra API client starting with v2.1. Please use get_all_groups() which supports pagination"
-        )
-
-    @validate_gte_api_v3_2
-    def get_groups_by_name(self, name=None, description=None):
-        raise DeprecationWarning(
-            'This function has been deprecated in the Vectra API client starting with v2.1. Please use get_all_groups with the "description" query parameter'
-        )
-
-    @validate_gte_api_v2
-    def get_detect_usage(self, **kwargs):
-        """
-        Get average monthly IP count for Detect
-        :param start: starting month for the usage statistics - format YYYY-mm
-        :param end: end month for the usage statistics - format YYYY-mm
-        Default is statistics from last month
-        """
-        return self._request(
-            method="get",
-            url=f"{self.url}/usage/detect",
-            params=self._generate_detect_usage_params(kwargs),
-        )
-
-    @validate_api_v2
-    def get_audits(self, start_date=None, end_date=None):
-        """
-        Get audits between start_date and end_date, inclusive
-        :param start_date: start date (datetime.date), GMT, defaults to date.min
-        :param end_date: end date (datetime.date), GMT, defaults to date.max
-        """
-        if start_date is None and end_date is None:
-            return self._request(method="get", url=f"{self.url}/audits")
-        elif start_date is None and end_date is not None:
-            return self._request(
-                method="get", url=f"{self.url}/audits?end={end_date.isoformat()}"
-            )
-        elif start_date is not None and end_date is None:
-            return self._request(
-                method="get", url=f"{self.url}/audits?start={start_date.isoformat()}"
-            )
-        else:
-            return self._request(
-                method="get",
-                url=f"{self.url}/audits?start={start_date.isoformat()}&end={end_date.isoformat()}",
-            )
-
-
-class VectraClientV2_2(VectraClientV2_1):
-    VERSION3 = None
-    VERSION2 = 2.2
-    VERSION1 = None
-
-    def __init__(
-        self,
-        user=None,
-        password=None,
-        token=None,
-        url=None,
-        client_id=None,
-        secret_key=None,
-        verify=False,
-    ):
-        """
-        Initialize Vectra client
-        :param url: IP or hostname of Vectra brain (ex https://www.example.com) - required
-        :param token: API token for authentication when using API v2*
-        :param verify: Verify SSL (default: False) - optional
-        """
-        super().__init__(
-            url=url,
-            client_id=client_id,
-            secret_key=secret_key,
-            token=token,
-            verify=verify,
-        )
-
-    @staticmethod
-    def _generate_assignment_params(args):
-        """
-        Generate query parameters for assignment queries based on provided args
-        :param args: dict of keys to generate query params
-        :rtype: dict
-        """
-        valid_keys = [
-            "accounts",
-            "assignees",
-            "created_after",
-            "fields",
-            "max_id",
-            "min_id",
-            "ordering",
-            "page",
-            "page_size",
-            "resolution",
-            "resolved",
-        ]
-
-        deprecated_keys = []
-
-        return _generate_params(args, valid_keys, deprecated_keys)
-
-    @validate_gte_api_v2
-    # TODO remove this function if APIv < 2.2. is officially retired
-    def get_account_by_id(self, account_id=None, **kwargs):
-        """
-        Get account by id
-        :param account_id: account id - required
-        :param fields: comma separated string of fields to be filtered and returned - optional
-            possible values are id, url, name, state, threat, certainty, severity, account_type,
-            tags, note, note_modified_by, note_modified_timestamp, privilege_level, privilege_category,
-            last_detection_timestamp, detection_set, probable_home
-        """
-        if not account_id:
-            raise ValueError("Account id required")
-
-        return self._request(
-            method="get",
-            url=f"{self.url}/accounts/{account_id}",
-            params=self._generate_account_params(kwargs),
-        )
-
-    @validate_gte_api_v3_3
-    def get_host_note(self, host_id=None):
-        """
-        Get host notes
-        :param host_id: host ID
-        """
-        if not host_id:
-            raise ValueError("Host id required")
-
-        return self._request(method="get", url=f"{self.url}/hosts/{host_id}/notes")
-
-    @validate_gte_api_v3_3
-    def set_host_note(self, host_id=None, note=""):
-        """
-        Set host note
-        :param host_id: host ID
-        :param note: content of the note to set
-        """
-        if isinstance(note, str):
-            payload = {"note": note}
-        else:
-            raise TypeError("Note must be of type str")
-
-        return self._request(
-            method="post", url=f"{self.url}/hosts/{host_id}/notes", json=payload
-        )
-
-    @validate_gte_api_v3_3
-    def update_host_note(self, host_id=None, note_id=None, note=""):
-        """
-        Set host note
-        :param host_id: host ID
-        :param note_id: ID of the note to update
-        :param note: updated content of the note
-        """
-        if isinstance(note, str):
-            payload = {"note": note}
-        else:
-            raise TypeError("Note must be of type str")
-
-        return self._request(
-            method="patch",
-            url=f"{self.url}/hosts/{host_id}/notes/{note_id}",
-            json=payload,
-        )
-
-    @validate_gte_api_v3_3
-    def delete_host_note(self, host_id=None, note_id=None):
-        """
-        Set host note
-        :param host_id: host ID
-        :param note_id: ID of the note to delete
-        """
-
-        return self._request(
-            method="delete", url=f"{self.url}/hosts/{host_id}/notes/{note_id}"
-        )
-
-    @validate_gte_api_v2
-    def get_detection_note(self, detection_id=None):
-        """
-        Get detection notes
-        :param detection_id: detection ID
-        """
-        if not detection_id:
-            raise ValueError("detection id required")
-
-        return self._request(
-            method="get", url=f"{self.url}/detections/{detection_id}/notes"
-        )
-
-    @validate_gte_api_v2
-    def set_detection_note(self, detection_id=None, note=""):
-        """
-        Set detection note
-        :param detection_id: detection ID
-        :param note: content of the note to set
-        """
-        if isinstance(note, str):
-            payload = {"note": note}
-        else:
-            raise TypeError("Note must be of type str")
-
-        return self._request(
-            method="post",
-            url=f"{self.url}/detections/{detection_id}/notes",
-            json=payload,
-        )
-
-    @validate_gte_api_v2
-    def update_detection_note(self, detection_id=None, note_id=None, note=""):
-        """
-        Set detection note
-        :param detection_id: detection ID
-        :param note_id: ID of the note to update
-        :param note: updated content of the note
-        """
-        if isinstance(note, str):
-            payload = {"note": note}
-        else:
-            raise TypeError("Note must be of type str")
-
-        return self._request(
-            method="patch",
-            url=f"{self.url}/detections/{detection_id}/notes/{note_id}",
-            json=payload,
-        )
-
-    @validate_gte_api_v2
-    def delete_detection_note(self, detection_id=None, note_id=None):
-        """
-        Set detection note
-        :param detection_id: detection ID
-        :param note_id: ID of the note to delete
-        """
-
-        return self._request(
-            method="delete", url=f"{self.url}/detections/{detection_id}/notes/{note_id}"
-        )
-
-    @validate_gte_api_v2
-    def get_account_note(self, account_id=None):
-        """
-        Get account notes
-        :param account_id: account ID
-        """
-        if not account_id:
-            raise ValueError("account id required")
-
-        return self._request(
-            method="get", url=f"{self.url}/accounts/{account_id}/notes"
-        )
-
-    @validate_gte_api_v2
-    def set_account_note(self, account_id=None, note=""):
-        """
-        Set account note
-        :param account_id: account ID
-        :param note: content of the note to set
-        """
-        if isinstance(note, str):
-            payload = {"note": note}
-        else:
-            raise TypeError("Note must be of type str")
-
-        return self._request(
-            method="post", url=f"{self.url}/accounts/{account_id}/notes", json=payload
-        )
-
-    @validate_gte_api_v2
-    def update_account_note(self, account_id=None, note_id=None, note=""):
-        """
-        Set account note
-        :param account_id: account ID
-        :param note_id: ID of the note to update
-        :param note: updated content of the note
-        """
-        if isinstance(note, str):
-            payload = {"note": note}
-        else:
-            raise TypeError("Note must be of type str")
-
-        return self._request(
-            method="patch",
-            url=f"{self.url}/accounts/{account_id}/notes/{note_id}",
-            json=payload,
-        )
-
-    @validate_gte_api_v2
-    def delete_account_note(self, account_id=None, note_id=None):
-        """
-        Set account note
-        :param account_id: account ID
-        :param note_id: ID of the note to delete
-        """
-
-        return self._request(
-            method="delete", url=f"{self.url}/accounts/{account_id}/notes/{note_id}"
-        )
-
-    @validate_gte_api_v2
-    def get_all_assignments(self, **kwargs):
-        """
-        Generator to retrieve all assignments - all parameters are optional
-        :param accounts: filter by accounts ([int])
-        :param assignees: filter by assignees (int)
-        :param created_after: filter by created after timestamp
-        :param page: page number to return (int)
-        :param page_size: number of object to return in response (int)
-        :param resolution: filter by resolution (int)
-        :param resolved: filters by resolved status (bool)
-        """
-        url = f"{self.url}/assignments"
-        params = self._generate_assignment_params(kwargs)
-        method = "get"
-        resp = self._request(
-            method=method,
-            url=url,
-            params=params,
-        )
-        yield resp
-
-        # page_size only used to identify number of pages. Not a valid param.
-        params["page_size"] = len(resp.json()["results"])
-
-        yield from self.yield_results(resp, method, params=params)
-
-    @validate_gte_api_v2
-    def create_account_assignment(self, account_id=None, user_id=None):
-        """
-        Create new assignment
-        :param assign_account_id: ID of the account to assign
-        :param assign_to_user_id: ID of the assignee
-        """
-        payload = {
-            "assign_account_id": account_id,
-            "assign_to_user_id": user_id,
-        }
-        return self._request(method="post", url=f"{self.url}/assignments", json=payload)
-
-    @validate_gte_api_v3_3
-    def create_host_assignment(self, host_id=None, user_id=None):
-        """
-        Create new assignment
-        :param assign_account_id: ID of the account to assign
-        :param assign_to_user_id: ID of the assignee
-        """
-        payload = {
-            "assign_host_id": host_id,
-            "assign_to_user_id": user_id,
-        }
-        return self._request(method="post", url=f"{self.url}/assignments", json=payload)
-
-    @validate_gte_api_v2
-    def update_assignment(self, assignment_id=None, user_id=None):
-        """
-        Update an existing assignment
-        :param assignment_id: ID of the assignment to update
-        :param assign_to_user_id: ID of the assignee
-        """
-        payload = {"assign_to_user_id": user_id}
-        return self._request(
-            method="put", url=f"{self.url}/assignments/{assignment_id}", json=payload
-        )
-
-    @validate_gte_api_v2
-    def delete_assignment(self, assignment_id=None):
-        """
-        Delete assignment
-        :param assignment_id: assignment ID
-        """
-        return self._request(
-            method="delete", url=f"{self.url}/assignments/{assignment_id}"
-        )
-
-    @validate_gte_api_v2
-    def set_assignment_resolved(
-        self,
-        assignment_id: int,
-        detection_ids: list,
-        outcome: int,
-        note: str,
-        mark_as_fixed: bool = None,
-        triage_as: str = None,
-    ):
-        """
-        Set an assignment as resolved
-        :param outcome: integer value corresponding to the following:
-            1: benign_true_positive
-            2: malicious_true_positive
-            3: false_positive
-        :param note: Note to add to fixed/triaged detections
-        :param triage_as: One-time triage detection(s) and rename as (str).
-        :param mark_as_fixed: mark the detection(s) as fixed (bool). Custom triage_as and mark_as_fixed are mutually exclusive.
-        :param detection_ids: list of detection IDs to fix/triage
-        """
-        if not triage_as and not mark_as_fixed:
-            raise ValueError("Either triage_as or mark_as_fixed are requited")
-
-        payload = {
-            "outcome": outcome,
-            "note": note,
-            "mark_as_fixed": mark_as_fixed,
-            "triage_as": triage_as,
-            "detection_ids": detection_ids,
-        }
-        return self._request(
-            method="put",
-            url=f"{self.url}/assignments/{assignment_id}/resolve",
-            json=payload,
-        )
-
-    @validate_gte_api_v2
-    def get_all_assignment_outcomes(self, **kwargs):
-        """
-        Get the outcome of a given assignment
-        :param :
-        """
-        url = f"{self.url}/assignment_outcomes"
-        method = "get"
-        resp = self._request(method=method, url=url)
-        yield resp
-
-        yield from self.yield_results(resp, method)
-
-    @validate_gte_api_v2
-    def get_assignment_outcome_by_id(self, assignment_outcome_id: int):
-        """
-        Describe an existing Assignment Outcome
-        :param assignment_outcome_id: ID of the Assignment Outcome you want details for.
-        """
-        return self._request(
-            method="get", url=f"{self.url}/assignment_outcomes/{assignment_outcome_id}"
-        )
-
-    @validate_gte_api_v2
-    def create_assignment_outcome(self, title: str, category: str):
-        """
-        Create a new custom Assignment Outcome
-        :param tile: title of the new Assignment Outcome to create.
-        :param category: one of benign_true_positive, malicious_true_positive or false_positive
-        """
-        if category not in [
-            "benign_true_positive",
-            "malicious_true_positive",
-            "false_positive",
-        ]:
-            raise ValueError("Invalid category provided")
-
-        payload = {"title": title, "category": category}
-        return self._request(
-            method="post", url=f"{self.url}/assignment_outcomes", json=payload
-        )
-
-    @validate_gte_api_v2
-    def update_assignment_outcome(self, outcome_id: int, title: str, category: str):
-        """
-        Update an existing custom Assignment Outcome
-        :param outcome_id:
-        :param tile: title of the new Assignment Outcome to create.
-        :param category: one of benign_true_positive, malicious_true_positive or false_positive
-        """
-        if category not in [
-            "benign_true_positive",
-            "malicious_true_positive",
-            "false_positive",
-        ]:
-            raise ValueError("Invalid category provided")
-
-        payload = {"title": title, "category": category}
-        return self._request(
-            method="put",
-            url=f"{self.url}/assignment_outcomes/{outcome_id}",
-            json=payload,
-        )
-
-    @validate_gte_api_v2
-    def delete_assignment_outcome(self, outcome_id: int):
-        """
-        Delete an existing custom Assignment Outcome
-        :param outcome_id: ID of the Assignment Outcome to delete
-        """
-        return self._request(
-            method="delete", url=f"{self.url}/assignment_outcomes/{outcome_id}"
-        )
-
-    @validate_api_v2
-    def get_sensor_registration_token(self):
-        """
-        Get the existing sensor registration token.
-        If no valid token has been created yet, this will return an empty JSON
-        """
-        response = self._request(method="get", url=f"{self.url}/sensor_token")
-        # GET returns an empty response of no valid token is found, but we want JSON
-        if len(response.content) < 1:
-            json_dict = {}
-            response._content = json.dumps(json_dict).encode("utf-8")
-        return response
+    # /sensor_token
 
     @validate_api_v2
     def create_sensor_registration_token(self):
@@ -3140,11 +1991,31 @@ class VectraClientV2_2(VectraClientV2_1):
         return self._request(method="delete", url=f"{self.url}/sensor_token")
 
     @validate_api_v2
-    def get_aws_external_connectors(self):
+    def get_sensor_registration_token(self):
         """
-        Get the configured external connectors for AWS.
+        Get the existing sensor registration token.
+        If no valid token has been created yet, this will return an empty JSON
         """
-        return self._request(method="get", url=f"{self.url}/settings/aws_connectors")
+        response = self._request(method="get", url=f"{self.url}/sensor_token")
+        # GET returns an empty response of no valid token is found, but we want JSON
+        if len(response.content) < 1:
+            json_dict = {}
+            response._content = json.dumps(json_dict).encode("utf-8")
+        return response
+
+    # /settings
+
+    @staticmethod
+    def _generate_internal_network_params(args):
+        """
+        Generate query parameters for internal network queries based on provided args based on provided args
+        :param args: dict of keys to generate query params
+        :rtype: dict
+        """
+        valid_keys = ["include_ipv4", "include_ipv6"]
+        deprecated_keys = []
+
+        return _generate_params(args, valid_keys, deprecated_keys)
 
     @validate_api_v2
     def create_aws_external_connector(
@@ -3175,225 +2046,77 @@ class VectraClientV2_2(VectraClientV2_1):
             method="post", url=f"{self.url}/settings/aws_connectors", json=payload
         )
 
-
-class VectraClientV2_4(VectraClientV2_2):
-    VERSION3 = None
-    VERSION2 = 2.4
-    VERSION1 = None
-
-    def __init__(
-        self,
-        user=None,
-        password=None,
-        token=None,
-        url=None,
-        client_id=None,
-        secret_key=None,
-        verify=False,
-    ):
+    @validate_api_v2
+    def get_aws_external_connectors(self):
         """
-        Initialize Vectra client
-        :param url: IP or hostname of Vectra brain (ex https://www.example.com) - required
-        :param token: API token for authentication when using API v2*
-        :param verify: Verify SSL (default: False) - optional
+        Get the configured external connectors for AWS.
         """
-        super().__init__(
-            url=url,
-            client_id=client_id,
-            secret_key=secret_key,
-            token=token,
-            verify=verify,
+        return self._request(method="get", url=f"{self.url}/settings/aws_connectors")
+
+    @validate_api_v2
+    def get_internal_networks(self):
+        """
+        Get all internal networks configured on the brain
+        """
+        return self._request(method="get", url=f"{self.url}/settings/internal_network")
+
+    @validate_api_v2
+    def set_internal_networks(self, include=[], exclude=[], drop=[], append=True):
+        """
+        Set internal networks configured on the brain
+        :param include: list of subnets to add the internal subnets list
+        :param exclude: list of subnets to exclude from the internal subnets list
+        :param drop: list of subnets to add to the drop list
+        :param append: overwrites existing lists if set to False, appends to existing lists if set to True
+        """
+        # Check that all provided ranges are valid
+        all(ipaddress.ip_network(i) for i in include + exclude + drop)
+
+        if append and all(isinstance(i, list) for i in [include, exclude, drop]):
+            current_list = self.get_internal_networks().json()
+            # We must make all entries unique
+            payload = {
+                "include": list(
+                    set(include).union(set(current_list["included_subnets"]))
+                ),
+                "exclude": list(
+                    set(exclude).union(set(current_list["excluded_subnets"]))
+                ),
+                "drop": list(set(drop).union(set(current_list["dropped_subnets"]))),
+            }
+        elif all(isinstance(i, list) for i in [include, exclude, drop]):
+            payload = {"include": include, "exclude": exclude, "drop": drop}
+        else:
+            raise TypeError("subnets must be of type list")
+
+        return self._request(
+            method="post", url=f"{self.url}/settings/internal_network", json=payload
         )
 
+    # /subnets
+
     @staticmethod
-    def _generate_group_params(args):
+    def _generate_subnet_params(args):
         """
-        Generate query parameters for groups based on provided args
+        Generate query parameters for subnet queries based on provided args
         :param args: dict of keys to generate query params
         :rtype: dict
         """
-        valid_keys = [
-            "account_ids",
-            "account_names",
-            "description",
-            "domains",
-            "host_ids",
-            "host_names",
-            "importance",
-            "ips",
-            "last_modified_by",
-            "last_modified_timestamp",
-            "membership_action",
-            "name",
-            "page",
-            "page_size",
-            "type",
-        ]
-
+        valid_keys = ["ordering", "search"]
         deprecated_keys = []
 
         return _generate_params(args, valid_keys, deprecated_keys)
 
-    @staticmethod
-    def _generate_host_params(args):
+    @validate_api_v2
+    def get_all_subnets(self, **kwargs):
         """
-        Generate query parameters for hosts based on provided args
-        :param args: dict of keys to generate query params
-        :rtype: dict
-
-        Valid params in the dict
-        :param all: if set to False, endpoint will only return hosts that have active detections, active traffic or are marked as key assets - default False
-        :param active_traffic: only return hosts that have seen traffic in the last 2 hours (bool)
-        :param c_score: certainty score (int) - will be removed with deprecation of v1 of api
-        :param c_score_gte: certainty score greater than or equal to (int) - will be removed with deprecation of v1 of api
-        :param certainty: certainty score (int)
-        :param certainty_gte: certainty score greater than or equal to (int)
-        :param fields: comma separated string of fields to be filtered and returned
-            possible values are: id,name,active_traffic,has_active_traffic,t_score,threat,c_score,
-            certainty,severity,last_source,ip,previous_ips,last_detection_timestamp,key_asset,
-            is_key_asset,state,targets_key_asset,is_targeting_key_asset,detection_set,
-            host_artifact_set,sensor,sensor_name,tags,note,note_modified_by,note_modified_timestamp,
-            url,host_url,last_modified,assigned_to,assigned_date,groups,has_custom_model,privilege_level,
-            privilege_category,probable_owner,detection_profile
-        :param has_active_traffic: host has active traffic (bool)
-        :param include_detection_summaries: include detection summary in response (bool)
-        :param is_key_asset: host is key asset (bool)
-        :param is_targeting_key_asset: host is targeting key asset (bool)
-        :param key_asset: host is key asset (bool) - will be removed with deprecation of v1 of api
-        :param last_detection_timestamp: timestamp of last detection on this host (datetime)
-        :param last_source: registered ip address modified timestamp greater than or equal to (datetime) of host
-        :param mac_address: registered mac address of host
-        :param max_id: maximum ID of host returned
-        :param min_id: minimum ID of host returned
-        :param name: registered name of host
-        :param note_modified_timestamp_gte: note last modified timestamp greater than or equal to (datetime)
-        :param ordering: field to use to order response
-        :param page: page number to return (int)
-        :param page_size: number of object to return in response (int)
-        :param privilege_category: privilege category of host (low/medium/high)
-        :param privilege_level: privilege level of host (0-10)
-        :param privilege_level_gte: privilege level of host greater than or equal to (int)
-        :param state: state of host (active/inactive)
-        :param t_score: threat score (int) - will be removed with deprecation of v1 of api
-        :param t_score_gte: threat score greater than or equal to (int) - will be removed with deprecation of v1 of api
-        :param tags: tags assigned to host
-        :param targets_key_asset: host is targeting key asset (bool)
-        :param threat: threat score (int)
-        :param threat_gte: threat score greater than or equal to (int)
-        :param last_detection_timestamp_gte: filter by last_detection_timestamp >= timestamp provided
-        :param last_detection_timestamp_lte: filter by last_detection_timestamp <= timestamp provided
+        Generator to get all subnets seen by the brain
+        :param ordering: ordering key of the results.
+            possible values are: subnet, hosts, firstSeen, lastSeen
+        :param search: only return subnets containing the search string
         """
-        valid_keys = [
-            "active_traffic",
-            "all",
-            "c_score",
-            "c_score_gte",
-            "certainty",
-            "certainty_gte",
-            "fields",
-            "has_active_traffic",
-            "include_detection_summaries",
-            "is_key_asset",
-            "is_targeting_key_asset",
-            "key_asset",
-            "last_detection_timestamp",
-            "last_source",
-            "mac_address",
-            "max_id",
-            "min_id",
-            "name",
-            "note_modified_timestamp_gte",
-            "ordering",
-            "page",
-            "page_size",
-            "privilege_category",
-            "privilege_level",
-            "privilege_level_gte",
-            "state",
-            "t_score",
-            "t_score_gte",
-            "tags",
-            "targets_key_asset",
-            "threat",
-            "threat_gte",
-            "last_detection_timestamp_gte",
-            "last_detection_timestamp_lte",
-        ]
-        deprecated_keys = [
-            "c_score",
-            "c_score_gte",
-            "key_asset",
-            "t_score",
-            "t_score_gte",
-            "targets_key_asset",
-        ]
-
-        return _generate_params(args, valid_keys, deprecated_keys)
-
-    @staticmethod
-    def _generate_account_params(args):
-        """
-        Generate query parameters for accounts based provided args
-        :param args: dict of keys to generate query params
-        :rtype: dict
-        """
-        valid_keys = [
-            "all",
-            "c_score",
-            "c_score_gte",
-            "certainty",
-            "certainty_gte",
-            "fields",
-            "first_seen",
-            "include_detection_summaries",
-            "last_seen",
-            "last_source",
-            "max_id",
-            "min_id",
-            "name",
-            "note_modified_timestamp_gte",
-            "ordering",
-            "page",
-            "page_size",
-            "privilege_category",
-            "privilege_level",
-            "privilege_level_gte",
-            "state",
-            "t_score",
-            "t_score_gte",
-            "tags",
-            "threat",
-            "threat_gte",
-            "uid",
-            "last_detection_timestamp_gte",
-            "last_detection_timestamp_lte",
-        ]
-
-        deprecated_keys = []
-
-        return _generate_params(args, valid_keys, deprecated_keys)
-
-    @validate_gte_api_v3_2
-    def get_all_groups(self, **kwargs):
-        """
-        Generator to retrieve all groups - all parameters are optional
-        :param account_ids: search for groups containing those account IDs (list)
-        :param account_names: search for groups containing those account names (list)
-        :param description: description of groups to search
-        :param domains: search for groups containing those domains (list)
-        :param host_ids: search for groups containing those host IDs (list)
-        :param host_names: search for groups containing those hosts (list)
-        :param importance: search for groups of this specific importance (One of "high", "medium", "low", or "never_prioritize")
-        :param ips: search for groups containing those IPs (list)
-        :param last_modified_by: username of last person to modify this group
-        :param last_modified_timestamp: timestamp of last modification of group (datetime)
-        :param name: name of groups to search
-        :param page: page number to return (int) TODO check
-        :param page_size: number of object to return in response (int) TODO check
-        :param type: type of group to search (domain/host/ip)
-        """
-        url = f"{self.url}/groups"
-        params = self._generate_group_params(kwargs)
+        url = f"{self.url}/subnets"
+        params = self._generate_subnet_params(kwargs)
         method = "get"
         resp = self._request(
             method=method,
@@ -3404,130 +2127,438 @@ class VectraClientV2_4(VectraClientV2_2):
 
         yield from self.yield_results(resp, method, params=params)
 
-    @validate_gte_api_v3_2
-    def create_group(self, name=None, description="", type=None, members=[], **kwargs):
+    @validate_api_v2
+    def get_all_sensor_subnets(self, sensor_luid=None, **kwargs):
         """
-        Create group
-        :param name: name of the group to create
-        :param description: description of the group
-        :param type: type of the group to create (account/domain/host/ip)
-        :param members: list of host/account ids to add to group
-        :rtype requests.Response:
+        Generator to get all subnets seen by a sensor
+        :param sensor_luid: LUID of the sensor for which to get the subnets seen - required
+        :param ordering: ordering key of the results.
+            possible values are: subnet, hosts, firstSeen, lastSeen
+        :param search: only return subnets containing the search string
         """
-        if not name:
-            raise ValueError("missing required parameter: name")
-        if not type:
-            raise ValueError("missing required parameter: type")
-        if type not in ["account", "host", "domain", "ip"]:
-            raise ValueError(
-                'parameter type must have value "account", "domain", "ip" or "host"'
-            )
-        if type == "domain" and members == []:
-            members = [""]
+        if not sensor_luid:
+            raise ValueError("Sensor LUID required")
 
-        if not isinstance(members, list):
-            raise TypeError("members must be type: list")
+        url = f"{self.url}/subnets/{sensor_luid}"
+        params = self._generate_subnet_params(kwargs)
+        method = "get"
+        resp = self._request(
+            method=method,
+            url=url,
+            params=params,
+        )
+        yield resp
+
+        yield from self.yield_results(resp, method, params=params)
+
+    # /tagging
+
+    @request_error_handler
+    @validate_api_v2
+    def bulk_delete_accounts_tag(self, tag, account_ids):
+        """
+        Delete a tag in bulk on multiple accounts. Only one tag can be deleted at a time
+        Note that account IDs in APIv2.1 are not the same IDs as seen in the UI
+        :param account_ids: IDs of the accounts on which to delete the tag
+        """
+        if not isinstance(account_ids, list):
+            raise TypeError("account IDs must be of type list")
+
+        payload = {"objectIds": account_ids, "tag": tag}
+        return self._request(
+            method="delete", url=f"{self.url}/tagging/account", json=payload
+        )
+
+    @validate_api_v2
+    def bulk_set_accounts_tag(self, tag, account_ids):
+        """
+        Set a tag in bulk on multiple accounts. Only one tag can be set at a time
+        Note that account IDs in APIv2.1 are not the same IDs as seen in the UI
+        :param account_ids: IDs of the accounts for which to set the tag
+        """
+        if not isinstance(account_ids, list):
+            raise TypeError("account IDs must be of type list")
+
+        payload = {"objectIds": account_ids, "tag": tag}
+        return self._request(
+            method="post", url=f"{self.url}/tagging/account", json=payload
+        )
+
+    @validate_api_v2
+    def bulk_delete_detections_tag(self, tag, detection_ids):
+        """
+        Delete a tag in bulk on multiple detections. Only one tag can be deleted at a time
+        :param detection_ids: IDs of the detections for which to delete the tag
+        """
+        if not isinstance(detection_ids, list):
+            raise TypeError("Detection IDs must be of type list")
+
+        payload = {"objectIds": detection_ids, "tag": tag}
+        return self._request(
+            method="delete", url=f"{self.url}/tagging/detection", json=payload
+        )
+
+    @validate_api_v2
+    def bulk_set_detections_tag(self, tag, detection_ids):
+        """
+        Set a tag in bulk on multiple detections. Only one tag can be set at a time
+        :param detection_ids: IDs of the detections for which to set the tag
+        """
+        if not isinstance(detection_ids, list):
+            raise TypeError("Detection IDs must be of type list")
+
+        payload = {"objectIds": detection_ids, "tag": tag}
+        return self._request(
+            method="post", url=f"{self.url}/tagging/detection", json=payload
+        )
+
+    @validate_api_v2
+    def bulk_delete_hosts_tag(self, tag, host_ids):
+        """
+        Delete a tag in bulk on multiple hosts. Only one tag can be deleted at a time
+        :param host_ids: IDs of the hosts on which to delete the tag
+        """
+        if not isinstance(host_ids, list):
+            raise TypeError("Host IDs must be of type list")
+
+        payload = {"objectIds": host_ids, "tag": tag}
+        return self._request(
+            method="delete", url=f"{self.url}/tagging/host", json=payload
+        )
+
+    @validate_api_v2
+    def bulk_set_hosts_tag(self, tag, host_ids):
+        """
+        Set a tag in bulk on multiple hosts. Only one tag can be set at a time
+        :param host_ids: IDs of the hosts for which to set the tag
+        """
+        if not isinstance(host_ids, list):
+            raise TypeError("Host IDs must be of type list")
+
+        payload = {"objectIds": host_ids, "tag": tag}
+        return self._request(
+            method="post", url=f"{self.url}/tagging/host", json=payload
+        )
+
+    @validate_gte_api_v2
+    def get_account_tags(self, account_id=None):
+        """
+        Get Account tags
+        :param account_id: ID of the account for which to retrieve the tags
+        """
+        return self._request(
+            method="get", url=f"{self.url}/tagging/account/{account_id}"
+        )
+
+    @validate_gte_api_v2
+    def get_detection_tags(self, detection_id=None):
+        """
+        Get detection tags
+        :param detection_id:
+        """
+        return self._request(
+            method="get", url=f"{self.url}/tagging/detection/{detection_id}"
+        )
+
+    @validate_gte_api_v2
+    def set_account_tags(self, account_id=None, tags=[], append=False):
+        """
+        Set account tags
+        :param account_id: ID of the account for which to set the tags
+        :param tags: list of tags to add to account
+        :param append: overwrites existing list if set to False, appends to existing tags if set to True
+        Set to empty list to clear tags (default: False)
+        """
+        if append and isinstance(tags, list):
+            current_list = self.get_account_tags(account_id=account_id).json()["tags"]
+            payload = {"tags": current_list + tags}
+        elif isinstance(tags, list):
+            payload = {"tags": tags}
+        else:
+            raise TypeError("tags must be of type list")
+
+        return self._request(
+            method="patch", url=f"{self.url}/tagging/account/{account_id}", json=payload
+        )
+
+    # /threatFeeds
+
+    @validate_gte_api_v3_3
+    def create_feed(self, name, category, certainty, itype, duration: int):
+        """
+        Creates new threat feed
+        ***Values for category, type, and certainty are case sensitive***
+        :param name: name of threat feed
+        :param category: category that detection will register. supported values are lateral, exfil, and cnc
+        :param certainty: certainty applied to detection. Supported values are Low, Medium, High
+        :param itype: indicator type - supported values are Anonymize, Exfiltration, Malware Artifacts, and Watchlist
+        :param duration: days that the threat feed will be applied
+        :returns: request object
+        """
+        category = category.lower()
+        certainty = certainty.capitalize()
+        itype = itype.capitalize()
+
+        if category not in ["lateral", "exfil", "cnc"]:
+            raise ValueError(f"Invalid category provided: {category}")
+
+        if certainty not in ["Low", "Medium", "High"]:
+            raise ValueError(f"Invalid certainty provided: {str(certainty)}")
+
+        if itype not in [
+            "Anonymize",
+            "Exfiltration",
+            "Malware Artifacts",
+            "Watchlist",
+            "C2",
+        ]:
+            raise ValueError(f"Invalid itype provided: {str(itype)}")
+
+        if not isinstance(duration, int):
+            raise ValueError(
+                "Invalid duration provided, duration must be an integer value"
+            )
 
         payload = {
-            "name": name,
-            "description": description,
-            "type": type,
-            "members": members,
+            "threatFeed": {
+                "name": name,
+                "defaults": {
+                    "category": category,
+                    "certainty": certainty,
+                    "indicatorType": itype,
+                    "duration": duration,
+                },
+            }
         }
 
-        for k, v in kwargs.items():
-            payload[k] = v
+        return self._request(method="post", url=f"{self.url}/threatFeeds", json=payload)
 
-        if self.VERSION3 is not None:
-            if "importance" not in payload:
-                payload["importance"] = "medium"
-        return self._request(method="post", url=f"{self.url}/groups", json=payload)
-
-    @validate_gte_api_v3_2
-    def update_group(
-        self, group_id, name=None, description="", members=[], append=False, **kwargs
-    ):
+    @validate_gte_api_v3_3
+    def delete_feed(self, feed_id=None):
         """
-        Update group
-        :param group_id: id of group to update
-        :param name: name of group
-        :param description: description of the group
-        :param members: list of members to add to group
-        :param append: set to True if appending to existing list (boolean)
+        Deletes threat feed from Vectra
+        :param feed_id: id of threat feed
         """
-        if not isinstance(members, list):
-            raise TypeError("members must be type: list")
+        return self._request(method="delete", url=f"{self.url}/threatFeeds/{feed_id}")
 
-        group = self.get_group_by_id(group_id=group_id).json()
+    @validate_gte_api_v2
+    def get_feed_by_name(self, name=None):
+        """
+        Gets configured threat feed by name
+        :param name: name of threat feed
+        """
         try:
-            id = group["id"]
-        except KeyError:
-            raise KeyError(f"Group with id {str(group_id)} was not found")
+            response = self._request(method="get", url=f"{self.url}/threatFeeds")
+        except requests.ConnectionError:
+            raise Exception("Unable to connect to remote host")
 
-        # Transform existing members into flat list as API returns dicts for host & account groups
-        if append:
-            if group["type"] in ["domain", "ip"]:
-                for member in group["members"]:
-                    members.append(member)
-            elif group["type"] == "account":
-                for member in group["members"]:
-                    members.append(member["uid"])
-            else:
-                for member in group["members"]:
-                    members.append(member["id"])
-        # Ensure members are unique
-        members = list(set(members))
+        if response.status_code == 200:
+            for feed in response.json()["threatFeeds"]:
+                if feed != []:
+                    if feed["name"].lower() == name.lower():
+                        return feed
+                else:
+                    return {}
+        else:
+            raise HTTPException(response)
 
-        name = name if name else group["name"]
-        description = description if description else group["description"]
+    @validate_gte_api_v2
+    def get_feeds(self):
+        """
+        Gets list of currently configured threat feeds
+        """
+        return self._request(method="get", url=f"{self.url}/threatFeeds")
 
-        payload = {"name": name, "description": description, "members": members}
-
-        for k, v in kwargs.items():
-            payload[k] = v
+    @validate_gte_api_v3_3
+    def post_stix_file(self, feed_id=None, stix_file=None):
+        """
+        Uploads STIX file to new threat feed or overwrites STIX file in existing threat feed
+        :param feed_id: id of threat feed
+        :param stix_file: stix filename
+        """
+        headers = copy.deepcopy(self.headers)
+        headers.pop("Content-Type", None)
         return self._request(
-            method="patch", url=f"{self.url}/groups/{id}", json=payload
+            method="post",
+            url=f"{self.url}/threatFeeds/{feed_id}",
+            headers=headers,
+            files={"file": open(stix_file)},
         )
 
-    @validate_gte_api_v3_2
-    def delete_group(self, group_id=None):
-        """
-        Delete group
-        :param group_id:
-        detections
-        """
-        return self._request(method="delete", url=f"{self.url}/groups/{group_id}")
+    # /traffic
 
-
-class VectraClientV2_5(VectraClientV2_4):
-    VERSION3 = None
-    VERSION2 = 2.5
-    VERSION1 = None
-
-    def __init__(
-        self,
-        user=None,
-        password=None,
-        token=None,
-        url=None,
-        client_id=None,
-        secret_key=None,
-        verify=False,
-    ):
+    @validate_api_v2
+    def get_all_sensor_traffic_stats(self, sensor_luid=None):
         """
-        Initialize Vectra client
-        :param url: IP or hostname of Vectra brain (ex https://www.example.com) - required
-        :param token: API token for authentication when using API v2*
-        :param verify: Verify SSL (default: False) - optional
+        Generator to get all traffic stats from a sensor
+        :param sensor_luid: LUID of the sensor for which to get the stats. Can be retrieved in the UI under Manage > Sensors
         """
-        super().__init__(
+        url = f"{self.url}/traffic/{sensor_luid}"
+        if not sensor_luid:
+            raise ValueError("Sensor LUID required")
+        method = "get"
+
+        resp = self._request(method=method, url=url)
+        yield resp
+
+        yield from self.yield_results(resp, method)
+
+    @validate_api_v2
+    def get_all_traffic_stats(self):
+        """
+        Generator to get all traffic stats
+        """
+        url = f"{self.url}/traffic"
+        method = "get"
+        resp = self._request(method=method, url=url)
+        yield resp
+
+        yield from self.yield_results(resp, method)
+
+    # /usage
+
+    @staticmethod
+    def _generate_detect_usage_params(args):
+        """
+        Generate query parameters for detect usage query based on provided args
+        :param args: dict of keys to generate query params
+        :rtype: dict
+        """
+        params = {}
+        search = re.compile("[0-9]{4}-[0-9]{2}")
+        valid_keys = ["start", "end"]
+        for k, v in args.items():
+            if k in valid_keys:
+                if v is not None:
+                    # We validate the parameters here as the error thrown by the endpoint is not very verbose
+                    if search.match(v):
+                        params[k] = v
+                    else:
+                        raise ValueError(
+                            f"{str(v)} is not a valid date string for detect usage query"
+                        )
+            else:
+                raise ValueError(
+                    f"argument {str(k)} is an invalid detect usage query parameter"
+                )
+        return params
+
+    @validate_gte_api_v2
+    def get_detect_usage(self, **kwargs):
+        """
+        Get average monthly IP count for Detect
+        :param start: starting month for the usage statistics - format YYYY-mm
+        :param end: end month for the usage statistics - format YYYY-mm
+        Default is statistics from last month
+        """
+        return self._request(
+            method="get",
+            url=f"{self.url}/usage/detect",
+            params=self._generate_detect_usage_params(kwargs),
+        )
+
+    # /users
+    @staticmethod
+    def _generate_user_params(args):
+        """
+        Generate query parameters for users based on provided args
+        :param args: dict of keys to generate query params
+        :rtype: dict
+
+        Valid params in the dict
+        :param username: filter by username
+        :param role: filter by role
+        :param account_type: filter by account type (local, ldap, radius or tacacs)
+        :param authentication_profile: filter by authentication profile
+        :param last_login_gte: filter for users that have logged in since the given timestamp
+        """
+        valid_keys = [
+            "username",
+            "role",
+            "account_type",
+            "authentication_profile",
+            "last_login_gte",
+        ]
+        deprecated_keys = []
+
+        return _generate_params(args, valid_keys, deprecated_keys)
+
+    @validate_gte_api_v3_3
+    def get_all_users(self, **kwargs):
+        """
+        Generator to query all users
+        For valid params, see _generate_user_params
+        """
+        url = f"{self.url}/users"
+        params = self._generate_user_params(kwargs)
+        method = "get"
+        resp = self._request(
+            method=method,
             url=url,
-            client_id=client_id,
-            secret_key=secret_key,
-            token=token,
-            verify=verify,
+            params=params,
+        )
+        yield resp
+
+        # page_size only used to identify number of pages. Not a valid param.
+        params["page_size"] = len(resp.json()["results"])
+
+        yield from self.yield_results(resp, method, params=params)
+
+    @validate_gte_api_v3_3
+    def get_user_by_id(self, user_id=None):
+        """
+        Get users by id
+        :param user: id of user to retrieve
+        """
+        if not user_id:
+            raise ValueError("User ID required")
+
+        # params = {"username": username}
+
+        return self._request(method="get", url=f"{self.url}/users/{user_id}")
+
+    @validate_gte_api_v3_3
+    def get_user_by_name(self, username=None):
+        """
+        Get users by name
+        :param user: name of user to retrieve
+        """
+        if not username:
+            raise ValueError("Username required")
+
+        params = {"username": username}
+
+        return self._request(method="get", url=f"{self.url}/users", params=params)
+
+    @validate_api_v2
+    def update_user(self, user_id=None, account_type=None, authentication_profile=None):
+        """
+        Update the authentication type for a user
+        :param user_id: user ID
+        :param account_type: new user account type (local, ldap, radius, tacacs)
+        :param authentication_profile: authentication profile name
+        """
+        if not user_id:
+            raise ValueError("User id required")
+
+        if account_type not in ["local", "ldap", "radius", "tacacs"]:
+            raise ValueError("Invalid account_type provided")
+
+        if account_type == "local":
+            authentication_profile is None
+        elif not authentication_profile:
+            raise ValueError("Authentication profile required")
+
+        payload = {
+            "account_type": account_type,
+            "authentication_profile": authentication_profile,
+        }
+
+        return self._request(
+            method="patch", url=f"{self.url}/users/{user_id}", json=payload
         )
 
+    # /vectra-match
     @staticmethod
     def _generate_vectramatch_params(args):
         """
@@ -3860,6 +2891,124 @@ class VectraClientV2_5(VectraClientV2_4):
                 if chunk:
                     file.write(chunk)
         return resp
+
+    @validate_gte_api_v2
+    def _toggle_detections_fixed(self, detection_ids, fixed):
+        """
+        Internal function to mark/unmark detections as fixed
+        """
+        payload = {"detectionIdList": detection_ids, "mark_as_fixed": str(fixed)}
+
+        return self._request(method="patch", url=f"{self.url}/detections", json=payload)
+
+    @validate_api_v2
+    def advanced_search(self, stype=None, page_size=50, query=None):
+        """
+        Advanced search
+        :param stype: search type (hosts, detections, accounts)
+        :param page_size: number of objects returned per page
+        :param advanced query (download the following guide for more details on query language
+            https://support.vectranetworks.com/hc/en-us/articles/360003225254-Search-Reference-Guide)
+        """
+        if stype not in ["hosts", "detections", "accounts"]:
+            raise ValueError(
+                "Supported values for stype are hosts, detections or accounts"
+            )
+
+        if not query:
+            raise ValueError("Query parameter is required")
+
+        params = {"page_size": page_size, "query_string": query}
+
+        resp = self._request(
+            method="get", url=f"{self.url}/search/{stype}", params=params
+        )
+        yield resp
+        while resp.json()["next"]:
+            resp = self._request(method="get", url=resp.json()["next"])
+            yield resp
+
+    @validate_gte_api_v3_3
+    def add_proxy(self, address=None, enable=True):
+        """
+        Add a proxy to the proxy list
+        :param address: IP address of the proxy to add
+        :param enable: set to true to consider the IP as a proxy, false to never consider it as proxy
+        """
+        payload = {"proxy": {"address": address, "considerProxy": enable}}
+
+        return self._request(method="post", url=f"{self.url}/proxies", json=payload)
+
+    @validate_gte_api_v3_3
+    def delete_proxy(self, proxy_id=None):
+        """
+        Delete a proxy from the proxy list
+        :param proxy_id: ID of the proxy to delete
+        """
+        return self._request(method="delete", url=f"{self.url}/proxies/{proxy_id}")
+
+    # TODO PATCH request modifies the proxy ID  and 404 is actually a 500 - APP-15864
+    @validate_gte_api_v3_3
+    def update_proxy(self, proxy_id=None, address=None, enable=True):
+        """
+        Update an existing proxy in the system
+        :param proxy_id: ID of the proxy to update
+        :param address: IP address to set for this proxy
+        :param enable: set to true to consider the IP as a proxy, false to never consider it as proxy
+        CAUTION: the proxy ID (resource identifier) gets modified by the PATCH request at the moment
+        CAUTION: PATCHing an invalid ID returns a HTTP 500 instead of 404 at the moment
+        """
+        if not proxy_id:
+            raise ValueError("Proxy id required")
+
+        payload = {"proxy": {}}
+        if address is not None:
+            payload["proxy"]["address"] = address
+        if enable is not None:
+            payload["proxy"]["considerProxy"] = enable
+
+        return self._request(
+            method="patch", url=f"{self.url}/proxies/{proxy_id}", json=payload
+        )
+
+    @validate_gte_api_v3_2
+    def create_group(self, name=None, description="", type=None, members=[], **kwargs):
+        """
+        Create group
+        :param name: name of the group to create
+        :param description: description of the group
+        :param type: type of the group to create (account/domain/host/ip)
+        :param members: list of host/account ids to add to group
+        :rtype requests.Response:
+        """
+        if not name:
+            raise ValueError("missing required parameter: name")
+        if not type:
+            raise ValueError("missing required parameter: type")
+        if type not in ["account", "host", "domain", "ip"]:
+            raise ValueError(
+                'parameter type must have value "account", "domain", "ip" or "host"'
+            )
+        if type == "domain" and members == []:
+            members = [""]
+
+        if not isinstance(members, list):
+            raise TypeError("members must be type: list")
+
+        payload = {
+            "name": name,
+            "description": description,
+            "type": type,
+            "members": members,
+        }
+
+        for k, v in kwargs.items():
+            payload[k] = v
+
+        if self.VERSION3 is not None:
+            if "importance" not in payload:
+                payload["importance"] = "medium"
+        return self._request(method="post", url=f"{self.url}/groups", json=payload)
 
 
 class ClientV2_latest(VectraClientV2_5):

--- a/modules/vectra.py
+++ b/modules/vectra.py
@@ -40,28 +40,23 @@ class HTTPException(Exception):
 
 
 class HTTPUnauthorizedException(HTTPException):
-    def __init__(self, response):
-        super().__init__(response)
+    """Catch 401 Unauthorized Exceptions"""
 
 
 class HTTPAlreadyExists(HTTPException):
-    def __init__(self, response):
-        super().__init__(response)
+    """Catch 409 Already Exists"""
 
 
 class HTTPRequestEntityTooLarge(HTTPException):
-    def __init__(self, response):
-        super().__init__(response)
+    """Catch 413 Rquest Entity Too Large"""
 
 
 class HTTPUnprocessableContentException(HTTPException):
-    def __init__(self, response):
-        super().__init__(response)
+    """Catch 422 Unprocessable Content"""
 
 
 class HTTPTooManyRequestsException(HTTPException):
-    def __init__(self, response):
-        super().__init__(response)
+    """Catch 429 Too Many Rquests"""
 
 
 def request_error_handler(func):
@@ -92,6 +87,7 @@ def request_error_handler(func):
 
 
 def deprecation(message):
+    """Decorator for deprecated methods"""
     warnings.warn(message, PendingDeprecationWarning)
 
 

--- a/modules/vectra.py
+++ b/modules/vectra.py
@@ -263,7 +263,7 @@ class VectraClientV2_5:
         if method not in ["get", "patch", "put", "post", "delete"]:
             raise ValueError("Invalid requests method provided")
 
-        if "headers" in kwargs.keys():
+        if "headers" in kwargs:
             headers = kwargs.pop("headers")
         else:
             headers = self.headers
@@ -420,7 +420,8 @@ class VectraClientV2_5:
         Generator to retrieve all accounts - all parameters are optional
         :param all: does nothing
         :param c_score: certainty score (int) - will be removed with deprecation of v1 of api
-        :param c_score_gte: certainty score greater than or equal to (int) - will be removed with deprecation of v1 of api
+        :param c_score_gte: certainty score greater than or equal to (int) - will be removed
+            with deprecation of v1 of api
         :param certainty: certainty score (int)
         :param certainty_gte: certainty score greater than or equal to (int)
         :param fields: comma separated string of fields to be filtered and returned
@@ -636,7 +637,8 @@ class VectraClientV2_5:
             3: false_positive
         :param note: Note to add to fixed/triaged detections
         :param triage_as: One-time triage detection(s) and rename as (str).
-        :param mark_as_fixed: mark the detection(s) as fixed (bool). Custom triage_as and mark_as_fixed are mutually exclusive.
+        :param mark_as_fixed: mark the detection(s) as fixed (bool). Custom triage_as and
+            mark_as_fixed are mutually exclusive.
         :param detection_ids: list of detection IDs to fix/triage
         """
         if not triage_as and not mark_as_fixed:
@@ -781,7 +783,8 @@ class VectraClientV2_5:
         :param state: campaign state, possible values are: init, active, closed, closed_never_active
         :param name: filter on campaign name
         :param last_updated_gte: return only campaigns with a last updated timestamp gte (datetime)
-        :param note_modified_timestamp_gte: return only campaigns with a last updated timestamp on their note gte (datetime)
+        :param note_modified_timestamp_gte: return only campaigns with a last updated timestamp on
+            their note gte (datetime)
         :param fields: comma separated string of fields to be filtered and returned
             possible values are: id, dst_ip, target_domain, state, name, last_updated,
             note, note_modified_by, note_modified_timestamp
@@ -854,7 +857,8 @@ class VectraClientV2_5:
 
         Valid params in the dict
                 :param c_score: certainty score (int) - will be removed with deprecation of v1 of api
-        :param c_score_gte: certainty score greater than or equal to (int) - will be removed with deprecation of v1 of api
+        :param c_score_gte: certainty score greater than or equal to (int) - will be removed with
+            deprecation of v1 of api
         :param category: detection category - will be removed with deprecation of v1 of api
         :param certainty: certainty score (int)
         :param certainty_gte: certainty score greater than or equal to (int)
@@ -881,7 +885,8 @@ class VectraClientV2_5:
         :param src_ip: source ip address of host attributed to detection
         :param state: state of detection (active/inactive)
         :param t_score: threat score (int) - will be removed with deprecation of v1 of api
-        :param t_score_gte: threat score is greater than or equal to (int) - will be removed with deprecation of v1 of api
+        :param t_score_gte: threat score is greater than or equal to (int) - will be removed with
+            deprecation of v1 of api
         :param tags: tags assigned to detections; this uses substring matching
         :param targets_key_asset: detection targets key asset (bool) - will be removed with deprecation of v1 of api
         :param threat: threat score (int)
@@ -1039,7 +1044,7 @@ class VectraClientV2_5:
         )
 
     @validate_gte_api_v2
-    def set_detection_tags(self, detection_id=None, tags=[], append=False):
+    def set_detection_tags(self, detection_id=None, tags=None, append=False):
         """
         Set  detection tags
         :param detection_id:
@@ -1132,7 +1137,8 @@ class VectraClientV2_5:
         :param domains: search for groups containing those domains (list)
         :param host_ids: search for groups containing those host IDs (list)
         :param host_names: search for groups containing those hosts (list)
-        :param importance: search for groups of this specific importance (One of "high", "medium", "low", or "never_prioritize")
+        :param importance: search for groups of this specific importance (One of "high", "medium",
+            "low", or "never_prioritize")
         :param ips: search for groups containing those IPs (list)
         :param last_modified_by: username of last person to modify this group
         :param last_modified_timestamp: timestamp of last modification of group (datetime)
@@ -1161,11 +1167,9 @@ class VectraClientV2_5:
         """
         return self._request(method="get", url=f"{self.url}/groups/{group_id}")
 
-
-
     @validate_gte_api_v3_2
     def update_group(
-        self, group_id, name=None, description="", members=[], append=False, **kwargs
+        self, group_id, name=None, description="", members=None, append=False, **kwargs
     ):
         """
         Update group
@@ -1278,10 +1282,12 @@ class VectraClientV2_5:
         :rtype: dict
 
         Valid params in the dict
-        :param all: if set to False, endpoint will only return hosts that have active detections, active traffic or are marked as key assets - default False
+        :param all: if set to False, endpoint will only return hosts that have active detections,
+            active traffic or are marked as key assets - default False
         :param active_traffic: only return hosts that have seen traffic in the last 2 hours (bool)
         :param c_score: certainty score (int) - will be removed with deprecation of v1 of api
-        :param c_score_gte: certainty score greater than or equal to (int) - will be removed with deprecation of v1 of api
+        :param c_score_gte: certainty score greater than or equal to (int) - will be removed with
+            deprecation of v1 of api
         :param certainty: certainty score (int)
         :param certainty_gte: certainty score greater than or equal to (int)
         :param fields: comma separated string of fields to be filtered and returned
@@ -1450,7 +1456,7 @@ class VectraClientV2_5:
         )
 
     @validate_gte_api_v3_3
-    def set_host_tags(self, host_id=None, tags=[], append=False):
+    def set_host_tags(self, host_id=None, tags=None, append=False):
         """
         Set host tags
         :param host_id:
@@ -1794,17 +1800,16 @@ class VectraClientV2_5:
                 'The "name" argument will be removed from this function, please use get_all_rules with the "contains" query parameter'
             )
             return self.get_rules_by_name(triage_category=name)
-        elif rule_id:
+        if rule_id:
             deprecation(
                 'The "rule_id" argument will be removed from this function, please use the corresponding get_rule_by_id function'
             )
             return self.get_rule_by_id(rule_id)
-        else:
-            return self._request(
-                method="get",
-                url=f"{self.url}/rules",
-                params=self._generate_rule_params(kwargs),
-            )
+        return self._request(
+            method="get",
+            url=f"{self.url}/rules",
+            params=self._generate_rule_params(kwargs),
+        )
 
     @validate_gte_api_v2
     def get_rules_by_name(self, triage_category=None, description=None):
@@ -1819,7 +1824,7 @@ class VectraClientV2_5:
         return self.get_rules(contains=search_query)
 
     @validate_api_v2
-    def mark_detections_custom(self, detection_ids=[], triage_category=None):
+    def mark_detections_custom(self, detection_ids=None, triage_category=None):
         """
         Mark detections as custom
         :param detection_ids: list of detection IDs to mark as custom
@@ -1834,7 +1839,7 @@ class VectraClientV2_5:
         return self._request(method="post", url=f"{self.url}/rules", json=payload)
 
     @validate_api_v2
-    def unmark_detections_custom(self, detection_ids=[]):
+    def unmark_detections_custom(self, detection_ids=None):
         """
         Unmark detection as custom
         :param detection_ids: list of detection IDs to unmark as custom
@@ -1847,7 +1852,8 @@ class VectraClientV2_5:
 
         response = self._request(method="delete", url=f"{self.url}/rules", json=payload)
 
-        # DELETE returns an empty response, but we populate the response for consistency with the mark_as_fixed() function
+        # DELETE returns an empty response, but we populate the response for consistency with the
+        #   mark_as_fixed() function
         json_dict = {
             "_meta": {"message": "Successfully unmarked detections", "level": "Success"}
         }
@@ -2061,7 +2067,7 @@ class VectraClientV2_5:
         return self._request(method="get", url=f"{self.url}/settings/internal_network")
 
     @validate_api_v2
-    def set_internal_networks(self, include=[], exclude=[], drop=[], append=True):
+    def set_internal_networks(self, include=None, exclude=None, drop=None, append=True):
         """
         Set internal networks configured on the brain
         :param include: list of subnets to add the internal subnets list
@@ -2069,6 +2075,10 @@ class VectraClientV2_5:
         :param drop: list of subnets to add to the drop list
         :param append: overwrites existing lists if set to False, appends to existing lists if set to True
         """
+        drop = [] if drop is None else drop
+        exclude = [] if exclude is None else exclude
+        include = [] if include is None else include
+
         # Check that all provided ranges are valid
         all(ipaddress.ip_network(i) for i in include + exclude + drop)
 
@@ -2261,7 +2271,7 @@ class VectraClientV2_5:
         )
 
     @validate_gte_api_v2
-    def set_account_tags(self, account_id=None, tags=[], append=False):
+    def set_account_tags(self, account_id=None, tags=None, append=False):
         """
         Set account tags
         :param account_id: ID of the account for which to set the tags
@@ -2391,7 +2401,8 @@ class VectraClientV2_5:
     def get_all_sensor_traffic_stats(self, sensor_luid=None):
         """
         Generator to get all traffic stats from a sensor
-        :param sensor_luid: LUID of the sensor for which to get the stats. Can be retrieved in the UI under Manage > Sensors
+        :param sensor_luid: LUID of the sensor for which to get the stats. Can be retrieved in the
+            UI under Manage > Sensors
         """
         url = f"{self.url}/traffic/{sensor_luid}"
         if not sensor_luid:
@@ -2586,7 +2597,7 @@ class VectraClientV2_5:
         Get all currently available devices
         """
         return requests.get(
-            "{url}/vectra-match/available-devices".format(url=self.url),
+            f"{self.url}/vectra-match/available-devices",
             headers=self.headers,
             verify=self.verify,
         )
@@ -2605,9 +2616,7 @@ class VectraClientV2_5:
             raise TypeError("Device serial must be of type string")
 
         return requests.get(
-            "{url}/vectra-match/enablement?device_serial={device_serial}".format(
-                url=self.url, device_serial=device_serial
-            ),
+            f"{self.url}/vectra-match/enablement?device_serial={device_serial}",
             headers=self.headers,
             verify=self.verify,
         )
@@ -2636,7 +2645,7 @@ class VectraClientV2_5:
         payload = {"device_serial": device_serial, "desired_state": state}
 
         return requests.post(
-            "{url}/vectra-match/enablement".format(url=self.url),
+            f"{self.url}/vectra-match/enablement",
             headers=self.headers,
             json=payload,
             verify=self.verify,
@@ -2655,14 +2664,12 @@ class VectraClientV2_5:
 
         if device_serial:
             return requests.get(
-                "{url}/vectra-match/status?device_serial={device_serial}".format(
-                    url=self.url, device_serial=device_serial
-                ),
+                f"{self.url}/vectra-match/status?device_serial={device_serial}",
                 headers=self.headers,
                 verify=self.verify,
             )
         return requests.get(
-            "{url}/vectra-match/status".format(url=self.url),
+            f"{self.url}/vectra-match/status",
             headers=self.headers,
             verify=self.verify,
         )
@@ -2680,14 +2687,12 @@ class VectraClientV2_5:
 
         if device_serial:
             return requests.get(
-                "{url}/vectra-match/stats?device_serial={device_serial}".format(
-                    url=self.url, device_serial=device_serial
-                ),
+                f"{self.url}/vectra-match/stats?device_serial={device_serial}",
                 headers=self.headers,
                 verify=self.verify,
             )
         return requests.get(
-            "{url}/vectra-match/stats".format(url=self.url),
+            f"{self.url}/vectra-match/stats",
             headers=self.headers,
             verify=self.verify,
         )
@@ -2705,14 +2710,12 @@ class VectraClientV2_5:
 
         if device_serial:
             return requests.get(
-                "{url}/vectra-match/alert-stats?device_serial={device_serial}".format(
-                    url=self.url, device_serial=device_serial
-                ),
+                f"{self.url}/vectra-match/alert-stats?device_serial={device_serial}",
                 headers=self.headers,
                 verify=self.verify,
             )
         return requests.get(
-            "{url}/vectra-match/alert-stats".format(url=self.url),
+            f"{self.url}/vectra-match/alert-stats",
             headers=self.headers,
             verify=self.verify,
         )
@@ -2732,7 +2735,7 @@ class VectraClientV2_5:
             raise TypeError("UUID must be of type string")
 
         return requests.get(
-            "{url}/vectra-match/rules?uuid={uuid}".format(url=self.url, uuid=uuid),
+            f"{self.url}/vectra-match/rules?uuid={uuid}",
             headers=self.headers,
             verify=self.verify,
         )
@@ -2765,7 +2768,7 @@ class VectraClientV2_5:
         del headers["Content-Type"]
 
         return requests.post(
-            "{url}/vectra-match/rules".format(url=self.url),
+            f"{self.url}/vectra-match/rules",
             headers=headers,
             files={"file": rule_file},
             data=payload,
@@ -2789,7 +2792,7 @@ class VectraClientV2_5:
         payload = {"uuid": uuid}
 
         return requests.delete(
-            "{url}/vectra-match/rules".format(url=self.url),
+            f"{self.url}/vectra-match/rules",
             headers=self.headers,
             json=payload,
             verify=self.verify,
@@ -2803,7 +2806,7 @@ class VectraClientV2_5:
         """
 
         return requests.get(
-            "{url}/vectra-match/assignment".format(url=self.url),
+            f"{self.url}/vectra-match/assignment",
             headers=self.headers,
             verify=self.verify,
         )
@@ -2832,7 +2835,7 @@ class VectraClientV2_5:
         payload = {"uuid": uuid, "device_serials": device_list}
 
         return requests.post(
-            "{url}/vectra-match/assignment".format(url=self.url),
+            f"{self.url}/vectra-match/assignment",
             headers=self.headers,
             json=payload,
             verify=self.verify,
@@ -2862,7 +2865,7 @@ class VectraClientV2_5:
         payload = {"uuid": uuid, "device_serial": device_serial}
 
         return requests.delete(
-            "{url}/vectra-match/assignment".format(url=self.url),
+            f"{self.url}/vectra-match/assignment",
             headers=self.headers,
             json=payload,
             verify=self.verify,
@@ -2972,7 +2975,9 @@ class VectraClientV2_5:
         )
 
     @validate_gte_api_v3_2
-    def create_group(self, name=None, description="", type=None, members=[], **kwargs):
+    def create_group(
+        self, name=None, description="", type=None, members=None, **kwargs
+    ):
         """
         Create group
         :param name: name of the group to create

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vectra-api-tools"
-version = "3.4.1_rc1"
+version = "3.4.10"
 authors = [
   { name="Brandon Wyatt", email="bwyatt@vectra.ai" },
+  { name="Chris Johnson", email=cjohnson@vectra.ai" },
+  { name="Eric Martin", email="emartin@vectra.ai" },
   { name="Vectra", email="tme@vectra.ai" },
 ]
 description = "Vectra API client library"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description="Vectra API client library",
     long_description=long_desc,
     long_description_content_type="text/markdown",
-    version="3.4.0",
+    version="3.4.10",
     author="Vectra",
     author_email="bwyatt@vectra.ai",
     url="https://github.com/vectranetworks/vectra_api_tools",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,24 +1,17 @@
 """
 Setup testing environment
 """
+
 import pytest
-import requests
+from urllib3 import disable_warnings
 
 from ..modules import platform
 from ..modules import vectra
 
 VectraClient = {
     # Vectra Detect client implementations
-    "1": vectra.VectraBaseClient,
-    "2.1": vectra.VectraClientV2_1,
-    "2.2": vectra.VectraClientV2_2,
-    "2.4": vectra.VectraClientV2_4,
     "2.5": vectra.VectraClientV2_5,
     # Vectra Platform client implementations
-    "3": platform.VectraPlatformClientV3,
-    "3.1": platform.VectraPlatformClientV3_1,
-    "3.2": platform.VectraPlatformClientV3_2,
-    "3.3": platform.VectraPlatformClientV3_3,
     "3.4": platform.VectraPlatformClientV3_4,
 }
 
@@ -33,7 +26,7 @@ def pytest_addoption(parser):
     parser.addoption("--user", help="username")
     parser.addoption("--password", help="password")
     parser.addoption("--token", help="token")
-    parser.addoption("--client_ver", help='|'.join(VectraClient.keys()))
+    parser.addoption("--client_ver", help="|".join(VectraClient.keys()))
 
 
 @pytest.fixture(scope="module")
@@ -41,18 +34,13 @@ def vc(request):
     """
     Create Vectra Client object
     """
-    requests.packages.urllib3.disable_warnings()
+    disable_warnings()
 
     client_ver = float(request.config.getoption("--client_ver"))
     if client_ver == 2:
-        raise ValueError(f"--client-ver must be one of {', '.join(VectraClient.keys())}")
-
-    if client_ver < 2:
-        brain = request.config.getoption("--url")
-        username = request.config.getoption("--user")
-        passwd = request.config.getoption("--password")
-
-        return vectra.VectraBaseClient(url=brain, user=username, password=passwd)
+        raise ValueError(
+            f"--client-ver must be one of {', '.join(VectraClient.keys())}"
+        )
 
     if 2 < client_ver < 3:
         version = request.config.getoption("--client_ver")

--- a/test/test_vectra_account.py
+++ b/test/test_vectra_account.py
@@ -1,6 +1,10 @@
-import requests
+"""
+Test the /accounts API Endpoint
+"""
 
-requests.packages.urllib3.disable_warnings()
+from urllib3 import disable_warnings
+
+disable_warnings()
 
 
 def test_account_generator(vc):
@@ -23,6 +27,9 @@ def test_accounts_threaded(vc):
 
 
 def test_get_accounts_id(vc):
+    """
+    Test a random account, and attempt to fetch it by the ID obtained
+    """
     account_id = next(vc.get_all_accounts()).json()["results"][0]["id"]
     resp = vc.get_account_by_id(account_id=account_id)
 
@@ -30,6 +37,9 @@ def test_get_accounts_id(vc):
 
 
 def test_account_tags(vc):
+    """
+    Test Account Tags
+    """
     account = next(vc.get_all_accounts()).json()["results"][0]
     account_id = account["id"]
     account_tags = account["tags"]

--- a/test/test_vectra_adv_search.py
+++ b/test/test_vectra_adv_search.py
@@ -1,11 +1,18 @@
-import pytest
-import requests
+"""
+Test the /search API Endpoint (v2 only)
+"""
 
-requests.packages.urllib3.disable_warnings()
+import pytest
+from urllib3 import disable_warnings
+
+disable_warnings()
 
 
 @pytest.fixture()
 def test_skip(vc):
+    """
+    Skip the test if it is not V2
+    """
     if vc.version not in [2.1, 2.2, 2.4, 2.5]:
         pytest.skip(
             allow_module_level=True,
@@ -30,14 +37,15 @@ def test_critical_quad_host_count(vc, test_skip):
 
 
 def test_ip_search(vc, test_skip):
+    """
+    Choose an IP address from a host, and obtain it via /hosts
+    """
     test_ip = next(vc.get_all_hosts()).json()["results"][-1]["last_source"]
 
     basic_host = next(vc.get_all_hosts(last_source=test_ip)).json()["results"][0]
 
     adv_host = next(
-        vc.advanced_search(
-            stype="hosts", query="host.last_source:{ip}".format(ip=test_ip)
-        )
+        vc.advanced_search(stype="hosts", query=f"host.last_source:{test_ip}")
     ).json()["results"][0]
 
     assert adv_host["id"] == basic_host["id"]

--- a/test/test_vectra_assignments.py
+++ b/test/test_vectra_assignments.py
@@ -1,10 +1,8 @@
 import random
-
 import pytest
-import requests
+from urllib3 import disable_warnings
 
-requests.packages.urllib3.disable_warnings()
-
+disable_warnings()
 global_dict = {}
 
 

--- a/test/test_vectra_detection.py
+++ b/test/test_vectra_detection.py
@@ -1,6 +1,6 @@
-import requests
+from urllib3 import disable_warnings
 
-requests.packages.urllib3.disable_warnings()
+disable_warnings()
 
 
 def test_detection_generator(vc):

--- a/test/test_vectra_entity.py
+++ b/test/test_vectra_entity.py
@@ -1,7 +1,12 @@
-import pytest
-import requests
+"""
+Test the /entities API endpoint (v3.x / RUX only)
+"""
 
-requests.packages.urllib3.disable_warnings()
+import pytest
+
+from urllib3 import disable_warnings
+
+disable_warnings()
 
 
 @pytest.fixture()

--- a/test/test_vectra_group.py
+++ b/test/test_vectra_group.py
@@ -1,5 +1,9 @@
 import pytest
 
+from urllib3 import disable_warnings
+
+disable_warnings()
+
 
 @pytest.fixture()
 def test_skip(vc):
@@ -54,13 +58,14 @@ def test_create_group(vc, test_skip):
 
 @pytest.mark.dependency(depends=["test_create_group"])
 def test_get_group_by_id(vc, test_skip):
+    """
+    Find the group we created in test_create_group
+    """
     groups = []
     for results in vc.get_all_groups():
         groups = groups + results.json()["results"]
 
-    for group in groups:
-        if group["name"] == "pytest group":
-            test_group = group
+    test_group = [x for x in groups if x["name"] == "pytest group"][0]
 
     resp = vc.get_group_by_id(test_group["id"])
     assert resp.json()["id"] == test_group["id"]

--- a/test/test_vectra_health.py
+++ b/test/test_vectra_health.py
@@ -1,7 +1,12 @@
-import pytest
-import requests
+"""
+Test /health API endpoint
+"""
 
-requests.packages.urllib3.disable_warnings()
+import pytest
+from urllib3 import disable_warnings
+
+disable_warnings()
+
 
 @pytest.fixture()
 def test_skip(vc):
@@ -11,13 +16,17 @@ def test_skip(vc):
             reason="Method is accessible via v2 and v3.3+ of API",
         )
 
+
 @pytest.fixture()
 def test_skip_34(vc):
+    """
+    Fixture to skip tests if the brain is not v3.4 or later"""
     if vc.version not in [3.4]:
         pytest.skip(
             allow_module_level=True,
             reason="Method is accessible v3.4+ of API",
         )
+
 
 def test_get_health(vc, test_skip):
     resp = vc.get_health_check()
@@ -26,6 +35,9 @@ def test_get_health(vc, test_skip):
 
 
 def test_get_health_check(vc, test_skip):
+    """
+    Test system health checks for QuadUX brains
+    """
     for c in [
         "network",
         "system",
@@ -41,7 +53,11 @@ def test_get_health_check(vc, test_skip):
         resp = vc.get_health_check(check=c)
         assert resp.status_code == 200
 
-def test_get_health_check(vc, test_skip_34):
+
+def test_get_health_check_3_4(vc, test_skip_34):
+    """
+    Test system health checks for RUX brains running 3.4 or later
+    """
     for c in [
         "detection",
         "external_connectors",

--- a/test/test_vectra_host.py
+++ b/test/test_vectra_host.py
@@ -1,7 +1,8 @@
 import pytest
-import requests
 
-requests.packages.urllib3.disable_warnings()
+from urllib3 import disable_warnings
+
+disable_warnings()
 
 
 @pytest.fixture()

--- a/test/test_vectra_proxies.py
+++ b/test/test_vectra_proxies.py
@@ -1,8 +1,8 @@
 import pytest
-import requests
 
-requests.packages.urllib3.disable_warnings()
+from urllib3 import disable_warnings
 
+disable_warnings()
 global_proxy = {}
 
 
@@ -20,6 +20,7 @@ def test_proxy_get(vc, test_skip):
 
     assert resp.status_code == 200
 
+
 @pytest.mark.dependency()
 def test_proxy_add(vc, test_skip):
     resp = vc.add_proxy(address="169.254.254.254", enable=True)
@@ -32,6 +33,7 @@ def test_proxy_add(vc, test_skip):
     assert proxy["ip"] == "169.254.254.254"
     assert proxy["considerProxy"] is True
 
+
 @pytest.mark.dependency(depends=["test_proxy_add"])
 def test_proxy_address_update(vc, test_skip):
     resp = vc.update_proxy(proxy_id=global_proxy["id"], address="169.254.254.253")
@@ -40,6 +42,7 @@ def test_proxy_address_update(vc, test_skip):
     assert resp.status_code == 200
     assert proxy["ip"] == "169.254.254.253"
     assert proxy["considerProxy"] is True
+
 
 @pytest.mark.dependency(depends=["test_proxy_add"])
 def test_proxy_state_update(vc, test_skip):
@@ -59,6 +62,7 @@ def test_proxy_state_update(vc, test_skip):
     for p in resp.json()["proxies"]:
         if p["address"] == proxy["ip"]:
             global_proxy["id"] = p["id"]
+
 
 @pytest.mark.dependency(depends=["test_proxy_add"])
 def test_proxy_delete(vc, test_skip):

--- a/test/test_vectra_rules.py
+++ b/test/test_vectra_rules.py
@@ -1,8 +1,7 @@
 import pytest
-import requests
+from urllib3 import disable_warnings
 
-requests.packages.urllib3.disable_warnings()
-
+disable_warnings()
 test_vars = {}
 
 

--- a/test/test_vectra_threat_feed.py
+++ b/test/test_vectra_threat_feed.py
@@ -1,10 +1,9 @@
 from pathlib import Path
 
 import pytest
-import requests
+from urllib3 import disable_warnings
 
-requests.packages.urllib3.disable_warnings()
-
+disable_warnings()
 test_vars = {}
 
 

--- a/test/test_vectra_user.py
+++ b/test/test_vectra_user.py
@@ -1,7 +1,7 @@
 import pytest
-import requests
+from urllib3 import disable_warnings
 
-requests.packages.urllib3.disable_warnings()
+disable_warnings()
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Added

-  default timeout of 30s and 180s for API v2 and v3 respectively

## Changed

- defining VectraPlatformClient._access_time in init()
- fixed .gitignore
- Flatted Vectra Client object, removing previous versions (these can be handled via previous published versions of this code, and via tags)

## Removed

- support for API v1
- duplicate static method _generate_campaign_params()